### PR TITLE
Added Telegram and Matrix links

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -99,8 +99,9 @@
   <p>Forking and maintaining separate distributions is encouraged. There is no official repo or website long-term.</p>
   <ul>
     <li> <strong>GitHub </strong><a href="https://github.com/handshake-org/">github.com/handshake-org</a></li>
-    <li> <strong>IRC </strong><a href="https://kiwi.freenode.net/#handshake">chat.freenode.net #handshake</a></li>
+    <li> <strong>IRC </strong><a href="https://kiwi.freenode.net/#handshake">chat.freenode.net #handshake</a> (or use the Matrix bridge <a href="https://matrix.to/#/#freenode_#handshake:matrix.org">here</a>)</li>
     <li> <strong>Reddit </strong><a href="https://reddit.com/r/handshake">reddit.com/r/handshake</a></li>
+    <li> <strong>Telegram </strong><a href="https://t.me/handshake_hns">t.me/handshake_hns</a></li>
   </ul>
 </div></div></section>
 

--- a/index.html
+++ b/index.html
@@ -116,9 +116,17 @@
         </p>
       </div>
       <div class='hero-info'>
+      	<p>
+          <strong>Telegram:</strong>
+          <a href='https://t.me/handshake_hns'>@handshake_hns</a>
+        </p>
         <p>
           <strong>IRC:</strong>
           <a href='https://kiwi.freenode.net/#handshake'>irc://irc.freenode.net/#handshake</a>
+        </p>
+         <p>
+          <strong>Matrix↔IRC Bridge:</strong>
+          <a href='https://matrix.to/#/#freenode_#handshake:matrix.org'>#freenode_#handshake:matrix.org</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Since most new IRC users never stay long enough for their queries to be answered, added links to matrix-irc bridge and telegram (@handshake_hns).


Signed-off-by: Anunay <me@anu.ninja>