### PR TITLE
Add telegram redirect link and add social embeds to both discord and telegram redirects

### DIFF
--- a/discord.html
+++ b/discord.html
@@ -18,7 +18,7 @@
 
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="handshake.au">
+    <meta property="twitter:domain" content="handshake.org">
     <meta property="twitter:url" content="https://handshake.org/discord">
     <meta name="twitter:title" content="Handshake Discord Server">
     <meta name="twitter:description" content="Decentralized certificate authority and naming">

--- a/telegram.html
+++ b/telegram.html
@@ -26,7 +26,7 @@
 
     <link rel="shortcut icon" href="https://handshake.org/img/favicon/hns-favicon.ico" type="image/x-icon">
 
-    <!-- After 0 seconds redirect user to Discord Invite Link -->
+    <!-- After 0 seconds redirect user to Telegram Invite Link -->
     <meta http-equiv="Refresh" content="0; url='https://t.me/handshake_hns'" />
 </head>
 

--- a/telegram.html
+++ b/telegram.html
@@ -18,7 +18,7 @@
 
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="handshake.au">
+    <meta property="twitter:domain" content="handshake.org">
     <meta property="twitter:url" content="https://handshake.org/telegram">
     <meta name="twitter:title" content="Handshake Telegram Group">
     <meta name="twitter:description" content="Decentralized certificate authority and naming">

--- a/telegram.html
+++ b/telegram.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 
 <head>
-    <title>Handshake Discord Server</title>
+    <title>Handshake Telegram</title>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
@@ -10,28 +10,28 @@
     <meta name="description" content="Decentralized certificate authority and naming" />
 
     <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://handshake.org/discord">
+    <meta property="og:url" content="https://handshake.org/telegram">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Handshake Discord Server">
+    <meta property="og:title" content="Handshake Telegram Group">
     <meta property="og:description" content="Decentralized certificate authority and naming">
     <meta property="og:image" content="https://www.handshake.org/images/landing/logo-dark.svg">
 
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta property="twitter:domain" content="handshake.au">
-    <meta property="twitter:url" content="https://handshake.org/discord">
-    <meta name="twitter:title" content="Handshake Discord Server">
+    <meta property="twitter:url" content="https://handshake.org/telegram">
+    <meta name="twitter:title" content="Handshake Telegram Group">
     <meta name="twitter:description" content="Decentralized certificate authority and naming">
     <meta name="twitter:image" content="https://www.handshake.org/images/landing/logo-dark.svg">
 
     <link rel="shortcut icon" href="https://handshake.org/img/favicon/hns-favicon.ico" type="image/x-icon">
 
     <!-- After 0 seconds redirect user to Discord Invite Link -->
-    <meta http-equiv="Refresh" content="0; url='https://discord.gg/Vq3PWF6cJ6'" />
+    <meta http-equiv="Refresh" content="0; url='https://t.me/handshake_hns'" />
 </head>
 
 <body>
-    Redirecting you to <a href="https://discord.gg/Vq3PWF6cJ6">https://discord.gg/Vq3PWF6cJ6</a>
+    Redirecting you to <a href="https://t.me/handshake_hns">https://t.me/handshake_hns</a>
 </body>
 
 </html>


### PR DESCRIPTION
This PR adds a link to the telegram channel from https://handshake.org/telegram
In addition the Discord redirect link (https://handshake.org/discord) doesn't have a social preview.
This PR adds these social previews to match the https://handshake.org previews.

These previews can be seen at
* [Current Discord redirect](https://opengraph.dev/panel?url=https%3A%2F%2Fhandshake.org%2Fdiscord)
* [New Discord redirect](https://opengraph.dev/panel?url=https%3A%2F%2F33-handshake.c.woodburn.au%2Fdiscord)
* [New Telegram redirect](https://opengraph.dev/panel?url=https%3A%2F%2F33-handshake.c.woodburn.au%2Ftelegram)
* [Handshake.org Home Page](https://opengraph.dev/panel?url=https%3A%2F%2Fhandshake.org)