### PR TITLE
Add regional groups to communities page

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -109,7 +109,7 @@
   <h2>REGIONAL COMMUNITIES</h2>
   <p>Join a regional community to discuss Handshake with people in your area.</p>
   <ul>
-    <li> <strong>Australia </strong><a href="https://hns.au">HNS AU</a></li>
+    <li> <strong>Australia </strong><a href="https://hns.au">HNS Australia</a></li>
     <li> <strong>Canada </strong><a href="https://hnscanada.ca/">HNS Canada</a></li>
   </ul>
 </div></div></section>

--- a/community/index.html
+++ b/community/index.html
@@ -105,13 +105,21 @@
     <li> <strong>Discord </strong><a href="/discord">handshake.org/discord</a></li>
   </ul>
 </div></div></section>
-
 <section class="light community"><div class="section-wrapper"><div>
+  <h2>REGIONAL COMMUNITIES</h2>
+  <p>Join a regional community to discuss Handshake with people in your area.</p>
+  <ul>
+    <li> <strong>Australia </strong><a href="https://hns.au">HNS AU</a></li>
+    <li> <strong>Canada </strong><a href="https://hnscanada.ca/">HNS Canada</a></li>
+  </ul>
+</div></div></section>
+
+<section class="default community"><div class="section-wrapper"><div>
   <h2>GRANTS AND SPONSORS</h2>
   <p>Please see the <a href="/grant-sponsors">Grants and Sponsors page</a> for details.</p>
 </div></div></section>
 
-<section class="default community"><div class="section-wrapper"><div>
+<section class="light community"><div class="section-wrapper"><div>
   <h2>DISCLAIMER</h2>
   <p>There is no singular official Handshake Project website, spokesperson, or repo. There is no official "team page".</p>
   <p>Every single person is a genuine and authorized Director of The Handshake Project.<!-- "A" Director, not "The" director--> If someone has given you a document or business card representing themselves as a Director of The Handshake Project, they have full authority to represent as Director of The Handshake Project with their own personal viewpoint, So Please Treat Them Right.<!--As Director, you have no obligation to listen to them.--> You, the reader, are also a Director of The Handshake Project and have equal claim on authority, action, and viewpoints.<!--You were already a Director of The Handshake Project, it does not need to be bestowed.--></p>


### PR DESCRIPTION
This pull request includes updates to the `community/index.html` file to enhance the community section by adding regional communities and adjusting the layout of existing sections.

Enhancements to community section:

* Added a new section for "REGIONAL COMMUNITIES" with links to Handshake communities in Australia and Canada.

Layout adjustments:

* Changed the section containing the "DISCLAIMER" from the "default" style to the "light" style to keep sections visually separated.