### PR TITLE
Refresh CSS styles, add wiki link to handypedia, and add light/dark mode

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -1,215 +1,270 @@
 <!DOCTYPE html>
 
 <html lang='en'>
-<head>
+  <head>
 
-  <title>Handshake</title>
+    <title>Handshake: Community</title>
 
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-  <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
-	<meta name="description" content="Decentralized certificate authority and naming" />
-	<meta property="og:title" content="Handshake" />
-	<meta property="og:description" content="Decentralized certificate authority and naming" />
-	<meta property="og:url" content="https://handshake.org" />
-	<meta property="og:image" content="https://www.handshake.org/images/landing/logo-dark.svg" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
+  	<meta name="description" content="Decentralized certificate authority and naming" />
+  	<meta property="og:title" content="Handshake" />
+  	<meta property="og:description" content="Decentralized certificate authority and naming" />
+  	<meta property="og:url" content="https://handshake.org" />
+  	<meta property="og:image" content="https://www.handshake.org/images/landing/logo-dark.svg" />
 
-  <link rel="shortcut icon" href="/img/favicon/hns-favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" type="text/css" href="/css/fonts/nitti.css" />
-  <link rel="stylesheet" type="text/css" href="/css/fonts/ibmplexmono.css" />
-  <link rel="stylesheet" type="text/css" href="/css/fonts/ibmplexsans.css" />
-  <link rel="stylesheet" type="text/css" href="/css/footer.css"/>
+    <link rel="shortcut icon" href="/img/favicon/hns-favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" type="text/css" href="/css/fonts/nitti.css" />
+    <link rel="stylesheet" type="text/css" href="/css/fonts/ibmplexmono.css" />
+    <link rel="stylesheet" type="text/css" href="/css/fonts/ibmplexsans.css" />
+    <link rel="stylesheet" type="text/css" href="/css/footer.css"/>
 
-  
+    
     <link rel="stylesheet" type="text/css" href="/css/marketing.css" />
-  
-  <style type="text/css">
-    .no-fouc {display: none;}
-</style>
+    <link rel="stylesheet" type="text/css" href="/css/refresh.css" />
 
-<script type="text/javascript">
-    document.documentElement.className = 'no-fouc';
-</script>
+  </head>
 
-</head>
+  <body class="landing">
 
-<body class="light">
-
-
-  <header><div class="header-wrapper"><div class="inner-wrapper">
-    <nav id="navBar" class="no-js nav-bar">
-
-  
-    <div id='nav-toggle' class="burgermenu" href="#">☰</div>
-
-    <div id='overlay'></div>
-    <div id="burgernav">
-      <ul>
-
-          <li><a href="https://handshake-org.github.io">Documentation</a></li>
-          <li><a href="/community">Community</a></li>
-          <li><a href="/faq">Faq</a></li>
-          
-          
-      </ul>
-    </div>
-  
-
-  <a class="nav-logo" href="/">
-    <img class='logo logo-dark' src='/images/landing/logo-dark.svg' /><img class='logo logo-light' src='/images/landing/logo-light.svg' />
-  </a>
-
-  
-    <div class="nav-right ">
-      <div class="nav-links "">
+    <header class="hero-section">
+      <nav id="navBar" class="nav-container no-js nav-bar">
+        
+        <div id='nav-toggle' class="burgermenu">☰</div>
+        <div id='overlay'></div>
+        
+        <div id="burgernav">
           <ul>
-            
-
-              <li><a href="https://handshake-org.github.io">Documentation</a></li>
-              <li><a href="/community">Community</a></li>
-              <li><a href="/faq">Faq</a></li>
-              
-              
-            
+            <li><a href="/community">Community</a></li>
+            <li><a href="https://handypedia.org" target="_blank">Wiki</a></li>
+            <li><a href="https://github.com/handshake-org" target="_blank">GitHub</a></li>
+            <li><a href="https://handshake-org.github.io">Docs</a></li>
+            <li><a href="/faq">Faq</a></li>
           </ul>
         </div>
-        
-        
-      </div>
-  
-</nav>
 
-  </div></div></header>
-
-  <div class="content">
-    <div class="wrapper">
-      
-
-
-<section class="community default"><div class="section-wrapper"><div class='hero-no-split'>
-  <h1>Handshake Community</h1>
-</div></div></section>
-
-<section class="light community"><div class="section-wrapper"><div>
-  <p><!--After Handshake is live, -->There is no official Handshake Foundation or entity. Handshake is a decentralized protocol and loose consensus on its software.</p>
-</div></div></section>
-
-<section class="default community"><div class="section-wrapper"><div>
-  <h2>COMMUNITY</h2>
-  <p>Forking and maintaining separate distributions is encouraged. There is no official repo or website long-term.</p>
-  <ul>
-    <li> <strong>GitHub </strong><a href="https://github.com/handshake-org/">github.com/handshake-org</a></li>
-    <li> <strong>IRC </strong><a href="https://web.libera.chat/#handshake">web.libera.chat/#handshake</a> (or use the Matrix bridge <a href="https://matrix.to/#/#handshake:libera.chat">here</a>)</li>
-    <li> <strong>Reddit </strong><a href="https://reddit.com/r/handshake">reddit.com/r/handshake</a></li>
-    <li> <strong>Telegram </strong><a href="https://t.me/handshake_hns">t.me/handshake_hns</a></li>
-    <li> <strong>Discord </strong><a href="/discord">handshake.org/discord</a></li>
-  </ul>
-</div></div></section>
-
-<section class="light community"><div class="section-wrapper"><div>
-  <h2>GRANTS AND SPONSORS</h2>
-  <p>Please see the <a href="/grant-sponsors">Grants and Sponsors page</a> for details.</p>
-</div></div></section>
-
-<section class="default community"><div class="section-wrapper"><div>
-  <h2>DISCLAIMER</h2>
-  <p>There is no singular official Handshake Project website, spokesperson, or repo. There is no official "team page".</p>
-  <p>Every single person is a genuine and authorized Director of The Handshake Project.<!-- "A" Director, not "The" director--> If someone has given you a document or business card representing themselves as a Director of The Handshake Project, they have full authority to represent as Director of The Handshake Project with their own personal viewpoint, So Please Treat Them Right.<!--As Director, you have no obligation to listen to them.--> You, the reader, are also a Director of The Handshake Project and have equal claim on authority, action, and viewpoints.<!--You were already a Director of The Handshake Project, it does not need to be bestowed.--></p>
-  <p>Any claims made by anyone on what Handshake does (or will do) does not necessarily have the agreement of other participants in the community and should not be seen as a definite certainty.</p>
-</div></div></section>
-
-</div> 
-</div> 
-
-
-
-<footer id='footer'>
-<!-- the onboarding pages and dashboard use the small footer -->
-  
-    <div class='footer-wrap'>
-  <nav>
-    <div class='header'>
-      <h3>Handshake</h3>
-      <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-      <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-    </div>
-    <div class='links'>
-      <a href='/'>Home</a>
-      <a href='/community'>Community</a>
-    </div>
-  </nav>
-
-  <nav>
-    <div class='header'>
-      <h3>Learn</h3>
-      <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-      <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-    </div>
-    <div class='links'>
-      <a href='/faq'>FAQ</a>
-      <a href='/files/handshake.txt'>Design Notes</a>
-    </div>
-  </nav>
-
-  <nav>
-    <div class='header'>
-      <h3>Develop</h3>
-      <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-      <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-    </div>
-    <div class='links'>
-      <a href='https://handshake-org.github.io'>Documentation</a>
-      <a href='https://github.com/handshake-org/hsd'>Run a full node</a>
-      <a href='https://github.com/handshake-org/hnsd'>Install an SPV resolver</a>
-      <a href='https://handshake-org.github.io/guides/auctions.html'>Auction system guide</a>
-    </div>
-  </nav>
-
-  <!-- Keeps things in line -->
-  <nav style="display:none;">
-  </nav>
-</div><!-- close center-wrap -->
-
-
-
-  
-    <div class='footer-wrap bottom-wrap'>
-      <a href='/'>
-        Home
-      </a>
-      <a href='/terms-of-use'>
-        Terms of Use
-      </a>
-      <a href='/privacy-policy'>
-          Privacy Policy
-      </a>
-      <a href='/trademark-disclaimer'>
-          Trademark Disclaimer
-      </a>
-
-      <nav class='social-icons-small-footer'>
-        <a href='https://github.com/handshake-org/'>
-          <img src='/img/footer/github.svg' alt='GitHub logo'/>
+        <a class="nav-logo logo-link" href="/">
+          <img class='logo logo-light header-logo' src='/images/landing/logo-light.svg' alt="Handshake Logo" />
+          <img class='logo logo-dark header-logo' src='/images/landing/logo-dark.svg' alt="Handshake Logo" />
         </a>
-        <a href='https://twitter.com/hns'>
-          <img src='/img/footer/twitter.svg' alt='Twitter logo'/>
-        </a>
-        <a href='https://reddit.com/r/handshake'>
-          <img src='/img/footer/reddit.svg' alt='Reddit logo'/>
-        </a>
+
+        <div class="nav-right">
+          <div class="nav-links">
+            <ul>
+              <li><a href="/community" class="nav-item">Community</a></li>
+              <li><a href="https://handypedia.org" target="_blank" class="nav-item wiki-link">Wiki</a></li>
+              <li><a href="https://github.com/handshake-org" target="_blank" class="nav-item">GitHub</a></li>
+              <li><a href="https://handshake-org.github.io" class="nav-item">Docs</a></li>
+              <li><a href="/faq" class="nav-item">Faq</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <button id="theme-toggle" style="background: none; border: 1px solid var(--accent-color); color: var(--accent-color); padding: 5px 15px; cursor: pointer; font-family: 'IBM Plex Mono', monospace;">
+            SWITCH MODE
+        </button>
       </nav>
-    </div>
-  
 
-</footer>
+      <div class="hero-content">
+        <h1>Handshake Community</h1>
+        <p class="subtitle">
+          There is no official Handshake Foundation or entity. Handshake is a decentralized protocol and loose consensus on its software.
+        </p>
+        <!-- editing out the buttons for now on Community page
+          <div class="hero-buttons">
+            <a href="https://handypedia.org/en/onboarding" target="_blank" class="btn-primary">Get Your Name</a>
+            <a href="https://handypedia.org" target="_blank" class="btn-secondary">Explore the Wiki</a>
+          </div>
+        -->
+      </div>
+    </header>
 
-<script src='/js/footer.js'></script>
-<script src='/js/nav.js'></script>
-<script>
-  window.addEventListener("load", function(e) {
-    document.documentElement.className = '';
-  });
-</script>
+    <div class="content">
+      <div class="wrapper">
+          
+        <section class="light community">
+          <div class="section-wrapper">
+            <div>
+              <h2>COMMUNITY</h2>
+              <p>Forking and maintaining separate distributions is encouraged. There is no official repo or website long-term.</p>
+              <ul>
+                <li> <strong>GitHub </strong><a href="https://github.com/handshake-org/">github.com/handshake-org</a></li>
+                <li> <strong>IRC </strong><a href="https://web.libera.chat/#handshake">web.libera.chat/#handshake</a> (or use the Matrix bridge <a href="https://matrix.to/#/#handshake:libera.chat">here</a>)</li>
+                <li> <strong>Reddit </strong><a href="https://reddit.com/r/handshake">reddit.com/r/handshake</a></li>
+                <li> <strong>Telegram </strong><a href="https://t.me/handshake_hns">t.me/handshake_hns</a></li>
+                <li> <strong>Discord </strong><a href="/discord">handshake.org/discord</a></li>
+              </ul>
+            </div>
+          </div>
+        </section>
 
-</body>
+        <section class="default community">
+          <div class="section-wrapper">
+            <div>
+              <h2>GRANTS AND SPONSORS</h2>
+              <p>Please see the <a href="/grant-sponsors">Grants and Sponsors page</a> for details.</p>
+            </div>
+          </div>
+        </section>
+
+        <section class="light community">
+          <div class="section-wrapper">
+            <div>
+              <h2>DISCLAIMER</h2>
+              <p>There is no singular official Handshake Project website, spokesperson, or repo. There is no official "team page".</p>
+              <p>Every single person is a genuine and authorized Director of The Handshake Project.<!-- "A" Director, not "The" director--> If someone has given you a document or business card representing themselves as a Director of The Handshake Project, they have full authority to represent as Director of The Handshake Project with their own personal viewpoint, So Please Treat Them Right.<!--As Director, you have no obligation to listen to them.--> You, the reader, are also a Director of The Handshake Project and have equal claim on authority, action, and viewpoints.<!--You were already a Director of The Handshake Project, it does not need to be bestowed.--></p>
+              <p>Any claims made by anyone on what Handshake does (or will do) does not necessarily have the agreement of other participants in the community and should not be seen as a definite certainty.</p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div> 
+
+
+
+    <footer id='footer'>
+    <!-- the onboarding pages and dashboard use the small footer -->
+      
+      <div class='footer-wrap'>
+        <nav>
+          <div class='header'>
+            <h3>Handshake</h3>
+            <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+            <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+          </div>
+          <div class='links'>
+            <a href='/'>Home</a>
+            <a href='/community'>Community</a>
+          </div>
+        </nav>
+
+        <nav>
+          <div class='header'>
+            <h3>Learn</h3>
+            <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+            <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+          </div>
+          <div class='links'>
+            <a href='/faq'>FAQ</a>
+            <a href='/files/handshake.txt'>Design Notes</a>
+          </div>
+        </nav>
+
+        <nav>
+          <div class='header'>
+            <h3>Develop</h3>
+            <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+            <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+          </div>
+          <div class='links'>
+            <a href='https://handshake-org.github.io'>Documentation</a>
+            <a href='https://github.com/handshake-org/hsd'>Run a full node</a>
+            <a href='https://github.com/handshake-org/hnsd'>Install an SPV resolver</a>
+            <a href='https://handshake-org.github.io/guides/auctions.html'>Auction system guide</a>
+          </div>
+        </nav>
+
+        <!-- Keeps things in line -->
+        <nav style="display:none;">
+        </nav>
+      </div><!-- close center-wrap -->
+
+      <div class='footer-wrap bottom-wrap'>
+        <a href='/'>
+          Home
+        </a>
+        <a href='/terms-of-use'>
+          Terms of Use
+        </a>
+        <a href='/privacy-policy'>
+            Privacy Policy
+        </a>
+        <a href='/trademark-disclaimer'>
+            Trademark Disclaimer
+        </a>
+
+        <nav class='social-icons-small-footer'>
+          <a href='https://github.com/handshake-org/'>
+            <img src='/img/footer/github.svg' alt='GitHub logo'/>
+          </a>
+          <a href='https://twitter.com/hns'>
+            <img src='/img/footer/twitter.svg' alt='Twitter logo'/>
+          </a>
+          <a href='https://reddit.com/r/handshake'>
+            <img src='/img/footer/reddit.svg' alt='Reddit logo'/>
+          </a>
+        </nav>
+      </div>
+
+    </footer>
+
+    <script src='/js/footer.js'></script>
+    <script src='/js/nav.js'></script>
+    <script>
+      window.addEventListener("load", function(e) {
+        document.documentElement.className = '';
+      });
+    </script>
+
+    <script>
+      // Manual toggle for the mobile menu
+      document.getElementById('nav-toggle').addEventListener('click', function() {
+        document.getElementById('burgernav').classList.toggle('open');
+        document.getElementById('overlay').classList.toggle('open');
+      });
+
+      // Close the menu if you click the overlay
+      document.getElementById('overlay').addEventListener('click', function() {
+        document.getElementById('burgernav').classList.remove('open');
+        document.getElementById('overlay').classList.remove('open');
+      });
+    </script>
+
+    <script>
+      // 1. REVEAL EFFECT (Keep this!)
+      const observerOptions = { threshold: 0.1 };
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('active');
+          }
+        });
+      }, observerOptions);
+
+      document.querySelectorAll('.reveal, section').forEach(el => {
+        observer.observe(el);
+      });
+
+      // --- THEME TOGGLE LOGIC ---
+      const themeToggle = document.getElementById('theme-toggle');
+      const htmlElement = document.documentElement;
+
+      function applyTheme(theme) {
+        const isDark = theme === 'dark';
+        htmlElement.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        
+        if (themeToggle) {
+          themeToggle.innerText = isDark ? 'LIGHT MODE' : 'DARK MODE';
+          // Use the variables directly or hardcode them to match the theme
+          themeToggle.style.borderColor = isDark ? '#00ff41' : '#0033ff';
+          themeToggle.style.color = isDark ? '#00ff41' : '#0033ff';
+        }
+      }
+
+      const savedTheme = localStorage.getItem('theme') || 'dark';
+      applyTheme(savedTheme);
+
+      if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+          const newTheme = htmlElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+          applyTheme(newTheme);
+        });
+      }
+
+      // Trigger once on load to set initial positions
+      window.dispatchEvent(new Event('scroll'));
+    </script>
+  </body>
 </html>

--- a/css/refresh.css
+++ b/css/refresh.css
@@ -1,0 +1,432 @@
+/* 1. CORE VARIABLES & THEMES */
+:root {
+  /* --- DARK MODE (DEFAULT) --- */
+  --bg-color: #0a0a0a;
+  --hero-bg: #0a0a0a; 
+  --hero-text: #ffffff;      
+  --accent: #00ff41;    
+  --btn-primary-text: #0a0a0a;
+  --btn-primary-hover-text: #0a0a0a;
+  --btn-primary-bg: var(--accent);
+  --btn-primary-shadow: rgba(0, 255, 65, 0.3);
+  --btn-secondary-border: rgba(255, 255, 255, 0.2);
+  --btn-secondary-text: #ffffff;
+  --footer-bg: #1a1a1a;
+  --section-light-bg: #1a1a1a;   
+  --section-default-bg: #0a0a0a; 
+  --section-text: #cccccc;       
+  --section-title: #ffffff;
+  --img-shadow: rgba(0, 255, 65, 2);
+}
+
+[data-theme="light"] {
+  --bg-color: #ffffff;
+  --hero-bg: #f0f4f2; 
+  --hero-text: #000000; 
+  --accent: #0033ff; 
+  --btn-primary-text: #0033ff;
+  --btn-primary-hover-text: #ffffff;
+  --btn-primary-bg: transparent;
+  --btn-primary-shadow: rgba(0, 51, 255, 0.3);
+  --btn-secondary-border: #333333;
+  --btn-secondary-text: #0033ff;
+  --footer-bg: #ffffff;
+  --section-light-bg: #ffffff;   
+  --section-default-bg: #f4f7f6; 
+  --section-text: #24292e;
+  --section-title: #000000;
+  --img-shadow: rgba(0, 51, 255, 0.2);
+}
+
+/* 2. BASE STYLES */
+body {
+  background-color: var(--bg-color);
+  color: var(--section-text);
+  font-family: "Nitti Light", Helvetica, sans-serif;
+  margin: 0;
+  line-height: 1.6;
+  transition: background-color 0.3s ease;
+}
+
+a, .accent {
+  color: var(--accent);
+  transition: color 0.3s ease;
+}
+
+.img-fluid {
+  transition: filter 0.3s ease, transform 0.3s ease;
+}
+
+.img-fluid:hover { transform: scale(1.02); }
+
+.img-fluid[src*="blocks.svg"] {
+  filter: drop-shadow(0 0 2px var(--img-shadow));
+}
+
+div.faucet-cta p {
+  color: #24292e !important;
+}
+
+div.faucet-cta h3 {
+  color: #000000 !important; /* this is for the open source dev block at bottom of homepage */
+}
+
+/* 3. BUTTON SYSTEM */
+.btn-primary, .btn-secondary {
+  font-family: 'IBM Plex Mono', monospace;
+  display: inline-block;
+  min-width: 220px; 
+  padding: 16px 32px;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: bold;
+  transition: all 0.3s ease;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  text-align: center;
+}
+
+.btn-primary {
+  background-color: var(--btn-primary-bg);
+  color: var(--btn-primary-text) !important;
+  border: 2px solid var(--accent);
+  box-shadow: 0 0 15px var(--btn-primary-shadow);
+}
+
+.btn-primary:hover {
+  background-color: var(--accent);
+  color: var(--btn-primary-hover-text) !important;
+  box-shadow: 0 0 25px var(--btn-primary-shadow);
+  transform: translateY(-2px);
+}
+
+.btn-secondary {
+  border: 2px solid var(--btn-secondary-border);
+  color: var(--btn-secondary-text);
+  backdrop-filter: blur(5px);
+}
+
+.btn-secondary:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(0, 255, 65, 0.05);
+}
+
+/* 4. NAVIGATION & LOGO */
+.nav-container {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  padding: 20px 60px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: border-box;
+  z-index: 100;
+}
+
+.logo-link { display: flex; align-items: center; }
+.header-logo { height: 64px; width: auto; }
+
+[data-theme="dark"] .logo-dark,
+[data-theme="light"] .logo-light { display: none !important; }
+[data-theme="dark"] .logo-light,
+[data-theme="light"] .logo-dark { display: block !important; }
+
+.nav-links ul {
+  list-style: none;
+  display: flex;
+  gap: 30px;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-item {
+  color: var(--accent) !important;
+  text-decoration: none;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 1px;
+}
+
+/* 5. HERO SECTION */
+.hero-section {
+  position: relative;
+  width: 100%;
+  min-height: 90vh;
+  background-color: var(--hero-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  z-index: 20; 
+  clip-path: polygon(
+    0 0, 
+    100% 0, 
+    100% calc(100% - 30px), 
+    93% calc(100% - 60px), 
+    85% calc(100% - 15px), 
+    76% calc(100% - 50px), 
+    65% calc(100% - 5px), 
+    55% calc(100% - 45px), 
+    44% calc(100% - 20px), 
+    34% calc(100% - 55px), 
+    23% calc(100% - 10px), 
+    12% calc(100% - 40px), 
+    5% calc(100% - 5px), 
+    0 calc(100% - 35px)
+  );
+}
+
+.hero-content {
+  text-align: center;
+  max-width: 800px;
+  padding: 0 20px;
+  margin-top: 60px;
+  z-index: 25;
+}
+
+.hero-section h1 { color: var(--hero-text) !important; }
+.subtitle {
+  color: var(--hero-text);
+  opacity: 0.8;
+  font-size: 1.2rem;
+  max-width: 700px;
+  margin: 0 auto 40px auto;
+}
+
+.protocol-status {
+  font-family: 'IBM Plex Mono', monospace;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 4px 12px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  margin-bottom: 24px;
+  background: rgba(0, 255, 65, 0.05);
+  display: inline-block;
+}
+
+/* 6. JAGGED SECTIONS */
+.content, .content .wrapper {
+  overflow: visible !important;
+}
+
+section {
+  position: relative;
+  padding: 160px 0 180px 0;
+  margin-bottom: -80px;
+  overflow: visible;
+  z-index: 10;
+}
+
+section:nth-of-type(1), .content section:first-of-type {
+  margin-top: -80px !important;
+  padding-top: 180px !important;
+}
+
+.section-wrapper {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 40px;
+}
+
+section.light { background-color: var(--section-light-bg) !important; }
+section.default { background-color: var(--section-default-bg) !important; }
+
+section.light, section.default {
+  clip-path: polygon(
+    0 35px, 
+    12% 10px, 
+    24% 55px, 
+    39% 20px, 
+    52% 60px, 
+    68% 15px, 
+    83% 45px, 
+    92% 5px, 
+    100% 30px, 
+    100% calc(100% - 30px), 
+    85% calc(100% - 55px), 
+    71% calc(100% - 15px), 
+    56% calc(100% - 60px), 
+    43% calc(100% - 25px), 
+    28% calc(100% - 50px), 
+    11% calc(100% - 10px), 
+    0 calc(100% - 40px)
+  );
+}
+
+section h1, section h2, section h3 { color: var(--section-title) !important; font-weight: 800; }
+section p, section ul li { color: var(--section-text); }
+
+ul.notes li:before { background-color: var(--section-text); } 
+
+/* 7. FOOTER STYLES */
+footer#footer {
+  margin-top: -80px; 
+  padding-top: 140px; 
+  background-color: var(--footer-bg) !important;
+  clip-path: polygon(
+    0 40px, 
+    7% 10px, 
+    15% 55px, 
+    26% 5px, 
+    35% 45px, 
+    46% 15px, 
+    54% 60px, 
+    65% 10px, 
+    76% 50px, 
+    87% 5px, 
+    95% 35px, 
+    100% 15px, 
+    100% 100%, 
+    0 100%
+  );
+  position: relative;
+  z-index: 30;
+  transition: background-color 0.3s ease;
+}
+
+footer#footer a, footer#footer p, footer#footer span {
+  color: var(--section-text) !important;
+}
+
+footer#footer h3, footer#footer h4 {
+  color: var(--section-title) !important;
+}
+
+[data-theme="light"] footer img {
+  filter: brightness(0) saturate(100%) invert(13%) sepia(10%) saturate(1202%) hue-rotate(169deg) brightness(96%) contrast(92%);
+}
+
+[data-theme="dark"] footer img {
+  filter: brightness(0) invert(1);
+}
+
+/* 8. MOBILE MENU */
+.burgermenu {
+  color: var(--accent) !important;
+  font-size: 32px;
+  cursor: pointer;
+  display: none;
+  z-index: 9999;
+}
+
+#burgernav {
+  position: fixed;
+  top: 0;
+  left: -300px;
+  width: 280px;
+  height: 100vh;
+  background: #0f0f0f;
+  transition: transform 0.4s ease;
+  z-index: 9998;
+  padding-top: 80px;
+  border-right: 2px solid var(--accent);
+}
+
+#burgernav.open { transform: translateX(300px); }
+
+/* 9. MEDIA QUERIES */
+@media (max-width: 768px) {
+  .nav-container { padding: 20px; }
+  .burgermenu { display: block; }
+  .nav-links { display: none; }
+  .header-logo { height: 48px; }
+  
+  /* Hero Buttons Stacked for Mobile */
+  .hero-buttons { 
+    display: flex;
+    flex-direction: column; 
+    gap: 15px; 
+    align-items: center;
+    width: 100%;
+  }
+  .btn-primary, .btn-secondary { width: 100%; max-width: 300px; }
+
+  .hero-section { 
+    min-height: 100vh; 
+    padding-bottom: 120px; 
+    clip-path: polygon(
+      0 0, 
+      100% 0, 
+      100% calc(100% - 15px), 
+      93% calc(100% - 30px), 
+      85% calc(100% - 8px), 
+      76% calc(100% - 25px), 
+      65% calc(100% - 3px), 
+      55% calc(100% - 22px), 
+      44% calc(100% - 10px), 
+      34% calc(100% - 28px), 
+      23% calc(100% - 5px), 
+      12% calc(100% - 20px), 
+      5% calc(100% - 3px), 
+      0 calc(100% - 18px)
+    );
+  }
+
+  /* Flattened Jagged Edges for Sections */
+  section { padding: 80px 0 100px 0; margin-bottom: -40px; }
+  
+  section.light, section.default {
+    clip-path: polygon(
+      0 15px, 
+      12% 5px, 
+      24% 25px, 
+      39% 10px, 
+      52% 30px, 
+      68% 8px, 
+      83% 20px, 
+      92% 5px, 
+      100% 15px, 
+      100% calc(100% - 15px), 
+      85% calc(100% - 25px), 
+      71% calc(100% - 8px), 
+      56% calc(100% - 30px), 
+      43% calc(100% - 12px), 
+      28% calc(100% - 25px), 
+      11% calc(100% - 5px), 
+      0 calc(100% - 20px)
+    );
+  }
+
+  section:nth-of-type(1), .content section:first-of-type {
+    margin-top: -40px !important; 
+    padding-top: 100px !important;
+  }
+
+  footer#footer {
+    margin-top: -40px !important; 
+    padding-top: 80px !important;
+    clip-path: polygon(
+      0 20px, 
+      7% 5px, 
+      15% 28px, 
+      26% 3px, 
+      35% 22px, 
+      46% 8px, 
+      54% 30px, 
+      65% 5px, 
+      76% 25px, 
+      87% 3px, 
+      95% 18px, 
+      100% 8px, 
+      100% 100%, 
+      0 100%
+    );
+  }
+}
+
+/* 10. UTILITIES */
+.reveal {
+  opacity: 0;
+  transform: translateY(40px);
+  transition: all 0.8s cubic-bezier(0.2, 1, 0.3, 1);
+}
+
+.reveal.active {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/faq/index.html
+++ b/faq/index.html
@@ -1,361 +1,388 @@
 <!DOCTYPE html>
 
 <html lang='en'>
-<head>
+  <head>
 
-  <title>Handshake</title>
+    <title>Handshake: FAQ</title>
 
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-  <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
-	<meta name="description" content="Decentralized certificate authority and naming" />
-	<meta property="og:title" content="Handshake" />
-	<meta property="og:description" content="Decentralized certificate authority and naming" />
-	<meta property="og:url" content="https://handshake.org" />
-	<meta property="og:image" content="https://www.handshake.org/images/landing/logo-dark.svg" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
+  	<meta name="description" content="Decentralized certificate authority and naming" />
+  	<meta property="og:title" content="Handshake" />
+  	<meta property="og:description" content="Decentralized certificate authority and naming" />
+  	<meta property="og:url" content="https://handshake.org" />
+  	<meta property="og:image" content="https://www.handshake.org/images/landing/logo-dark.svg" />
 
-  <link rel="shortcut icon" href="/img/favicon/hns-favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" type="text/css" href="/css/fonts/nitti.css" />
-  <link rel="stylesheet" type="text/css" href="/css/fonts/ibmplexmono.css" />
-  <link rel="stylesheet" type="text/css" href="/css/fonts/ibmplexsans.css" />
-  <link rel="stylesheet" type="text/css" href="/css/footer.css"/>
+    <link rel="shortcut icon" href="/img/favicon/hns-favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" type="text/css" href="/css/fonts/nitti.css" />
+    <link rel="stylesheet" type="text/css" href="/css/fonts/ibmplexmono.css" />
+    <link rel="stylesheet" type="text/css" href="/css/fonts/ibmplexsans.css" />
+    <link rel="stylesheet" type="text/css" href="/css/footer.css"/>
 
-  
+    
     <link rel="stylesheet" type="text/css" href="/css/marketing.css" />
-  
-  <style type="text/css">
-    .no-fouc {display: none;}
-</style>
+    <link rel="stylesheet" type="text/css" href="/css/refresh.css" />
 
-<script type="text/javascript">
-    document.documentElement.className = 'no-fouc';
-</script>
+  </head>
 
-</head>
+  <body class="landing">
 
-<body class="light">
-
-  <header><div class="header-wrapper"><div class="inner-wrapper">
-    <nav id="navBar" class="no-js nav-bar">
-
-  
-    <div id='nav-toggle' class="burgermenu" href="#">☰</div>
-
-    <div id='overlay'></div>
-    <div id="burgernav">
-      <ul>
-
-          <li><a href="https://handshake-org.github.io">Documentation</a></li>
-          <li><a href="/community">Community</a></li>
-          <li><a href="/faq">Faq</a></li>
-          
-          
-      </ul>
-    </div>
-  
-
-  <a class="nav-logo" href="/">
-    <img class='logo logo-dark' src='/images/landing/logo-dark.svg' /><img class='logo logo-light' src='/images/landing/logo-light.svg' />
-  </a>
-
-  
-    <div class="nav-right ">
-      <div class="nav-links "">
+    <header class="hero-section">
+      <nav id="navBar" class="nav-container no-js nav-bar">
+        
+        <div id='nav-toggle' class="burgermenu">☰</div>
+        <div id='overlay'></div>
+        
+        <div id="burgernav">
           <ul>
-            
-
-              <li><a href="https://handshake-org.github.io">Documentation</a></li>
-              <li><a href="/community">Community</a></li>
-              <li><a href="/faq">Faq</a></li>
-              
-              
-            
+            <li><a href="/community">Community</a></li>
+            <li><a href="https://handypedia.org" target="_blank">Wiki</a></li>
+            <li><a href="https://github.com/handshake-org" target="_blank">GitHub</a></li>
+            <li><a href="https://handshake-org.github.io">Docs</a></li>
+            <li><a href="/faq">Faq</a></li>
           </ul>
         </div>
-        
-        
-      </div>
-  
-</nav>
 
-  </div></div></header>
-  <div class="content">
-    <div class="wrapper">
-      
-
-
-  <section class="default"><div class="section-wrapper">
-    <div class="hero-no-split">
-      <h1>FAQ</h1>
-    </div>
-  </div></section>
-
-  <section id="faq" class="light"><div class="section-wrapper faq">
-    <div id='navigation' class="links">
-      <a id='general-link' class='active' href="#general">General</a>
-      <a id='naming-link' href="#naming">Naming</a>
-      <a id='grants-link' href="#grants">Community Grants</a>
-      <a id='using-link' href="#using">Using Handshake</a>
-    </div>
-    <div id="questions">
-      <h2 id="general">GENERAL</h2>
-      <!--
-      <div class="question">
-        <h3>Question goes here
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Answer goes here</p></span>
-      </div>
-      -->
-
-      <div class="question">
-        <h3>What does Handshake do?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Handshake is an experiment on collaborating to create a decentralized network which results in a global allocation of names. Think of the handles or usernames you use on services such as social networks, and domain names identifying the URI for websites. Nearly all of these services were provided by trusted third parties which prevent the web from truly being decentralized. Handshake provides a means, including key management and server/service authentication, for decentralized web services to experiment. The Internet currently relies upon a single trust root DNS zone and an amalgamation of private companies providing trusted Certificate Authorities to secure the internet, Handshake is an experiment and exploration in alternatives. By providing a way to do decentralized lookup of name records, one can produce hashes and keys to identify resources over decentralized networks without a trusted Certificate Authority corporation.</p></span>
-      </div>
-      <div class="question">
-        <h3>Why is canonicalization of naming within namespaces important?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Having a unique name on a particular namespace or zone is incredibly important for the security of the internet. Having a decentralized unique namespace could enable decentralized internet technologies. If you have a username on a social network, you may want a unique URI to view your profile. Similarly, for domain TLDs and other resources, it is helpful to know that you're correctly communicating with the desired endpoint. Without a unique namespace, the internet is vulnerable to either everyone having to type in the cryptographic key (making name lack usefulness), or a lack of agreement on the relationship between a resource and name. This has very severe security implications. Handshake's <a href="https://en.wikipedia.org/wiki/Zooko%27s_triangle">goal</a> is decentralization, canonicalization of names, <b>and</b> security. With the root zone in use as of the time of this writing (2019), internet naming does not provide decentralization, nor secure authenticated canonicalization of names (the Certificate Authority system).</p></span>
-      </div>
-      <div class="question">
-        <h3>How does Handshake work?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Handshake needs to reach global agreement on names and its owners. To do this, we need to develop ordering of when a name has already been registered in a decentralized way. In essence, we need decentralized global agreement on ordering. Handshake uses its own blockchain to do so. While there has been much misunderstanding on the purpose of a blockchain, the purpose is primarily to ordering events which occur over time (did A happen before B?). If no ordering of events are necessary, a blockchain is not needed. The Handshake blockchain creates an ordering of name registrations, so one knows when a name has already been registered. Without a global decentralized agreement on the order of registrations, we cannot know whether Alice owns the name or Bob does (did Bob make a false claim of registration after Alice already made one). Handshake has everyone run the same software rules so everyone can programmatically come to agreement on name ownership. When a name is registered, the owner has a cryptographic key which is under their control, which assigns ownership to themselves, and can write records on Handshake which identifies, authorizes, and locates resources associated with their name. As these records are also ordered, one can have greater assurance on whether the records are expired or current.</p></span>
-      </div>
-      <div class="question">
-        <h3>Does this promote carbon emissions?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Handshake uses proof-of-work mining, as it is currently the most reliable way to do compact light client proofs. Proof of work uses computational power, a lot of it. However, the overwhelming majority of this computational power is produced using renewables, currently wind and hydro. The reason proof-of-work is currently primarily renewables is that the competitive cost has driven down to places with <i>excess</i> energy, which are remote hydro and wind farms. While there are no guarantees this will persist, the percentage which uses renewables is increasing. In the future, it is possible to have it be a contributor to subsidizing off-grid solar power. As the grid becomes less viable due to local generation, it is possible that miners securing the network can provide an additional revenue stream. This isn't certain, but a theory is that if mining is secured by solar, the network security would be much higher, as that would mean that it requires significant investment in physical infrastructure to attack. This benefits people with off-grid solar panels, as their electricity is otherwise worthless after their batteries are fully charged. While it is uncertain if this will prove to be the case and alternatives should be ready, currently the overwhelming majority of proof of work mining using renewables is increasing.</p></span>
-      </div>
-      <div class="question">
-        <h3>When is the first handshake?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>On the 615817th Bitcoin block height, the BTC blockhash will be committed into the Handshake genesis block. While it can be immediately mined, the genesis block is only locked in after six confirmations. After the first six confirmations of valid Bitcoin blocks, the genesis block will not change, even with a deep reorg. The code is available for <a href="/download">download</a>. Transactions will enabled after two weeks worth of blocks.
-        </p></span>
-      </div>
-
-
-
-
-      <h2 id="naming">NAMING</h2>
-      <div class="question">
-        <h3>How do Internet names currently work?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>When a domain name is resolved to a corresponding server in the IP space, it uses a recursive DNS resolver such as Google's Public DNS server. DNS servers query a number of root servers maintained by one of 12 centralized entities. These root servers serve the "root zone". The root zone is the collection of Top Level Domains (TLDs) like .com, .net, .org, etc. </p></span>
-      </div>
-      <div class="question">
-        <h3>Why does the Certificate Authority system benefit from decentralization?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Compromised certificate authorities threaten SSL. Billions of dollars are currently being moved around on potentially insecure websites. If you’re personally identifiable as the owner of a valuable asset, there’s a risk to your personal safety. Even though WHOIS records have been scrubbed of private information — with the current naming system, your information can still be subpoenaed from a domain registrar. </p></span>
-      </div>
-      <div class="question">
-        <h3>What issues have occured with the centralized nature of the root zone and DNS as it currently stands?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Certificate authorities and private owners of TLDs impose fees while often compromising the security of SSL by issuing bad certificates or cooperating with government attempts to spy on encrypted traffic or censor undesirable content. One common mechanism of Internet censorship that has been used with increasing and alarming frequency is DNS filtering and redirection. Another area where the centralized nature of Internet names has come to a head is domain registration privacy. Additionally, the way DNS is currently centered at a handful of choke points allows for DDoS attacks like we saw in the 2016 attack on Dyn. </p></span>
-      </div>
-      <div class="question">
-        <h3>Does Handshake replace DNS?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>No. Handshake is meant to replace the root zone file, not DNS. Browsing the web with human readable names is what Internet users have gotten acclimated to. Our solution allows for a seamless transition between a centralized name root zone file controlled by  private parties to a decentralized root zone file controlled by actual Internet users. The Handshake blockchain itself is essentially one big distributed zone file in which anyone has the right to add an entry in. </p></span>
-      </div>
-      <div class="question">
-        <h3>What can you do with Handshake and DNS now?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Using OpenSSH, it’s possible to store SSH fingerprints in DNS. This means that if you're using a Handshake Name System (HNS) resolver, you can actually already verify SSH fingerprints in a decentralized way. This is possible without needing to install any additional, special SSH software. </p>
-              <p>DNS has an additional feature that allows you to verify TLS certificates by storing a hash of your ‘SubjectPublicKeyInfo’. This means that there is now a P2P way to trust self-signed certificates, as long as they have a valid DNSSEC trust chain set up. Anyone can set up a valid trust chain without having to ask anyone's permission to do so. </p></span>
-      </div>
-      <div class="question">
-        <h3>How is Handshake different from other decentralized naming projects?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Many other decentralized naming systems did not allow for secure “light clients” (simple payment verification mode), forcing every potential user to run a full node, equivalent to saving all the domains in the world on your computer. Another key differentiator is that Handshake is the first to pre-reserve names for existing trademark name holders. </p></span>
-      </div>
-
-      <h2 id="grants">COMMUNITY GRANTS</h2>
-      <div class="question">
-        <h3>Why is there a grant of $10.2 million to nonprofits and free/open source projects?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Handshake’s original incubators, Purse.io and Private Internet Access, provided enough support to build and launch the platform without additional funding. The pre-launch project contributors don’t require additional capital from subsequent investors, but what was needed is their deep expertise in early stage technology venture valuation. Accepting their investment at mutually agreed upon terms ensures Handshake launches at a reasonable valuation and enables the network to immediately bootstrap the decentralized market for Internet names. Beyond that Handshake has everything needed and that capital is better deployed by the FOSS organizations to which have been pledged to contribute it.
-        </p></span>
-      </div>
-      <div class="question">
-        <h3>Why are free and open source contributors receiving the majority of the initial HNS?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>The Internet, and civilization as a whole, would not be where it is today without the hard work of the free software and open source community and the projects that they work on. The Handshake blockchain will start with an initial supply of 1.36 billion coins, of which ~67.5% will be gifted to FLOSS developers and projects, as well as non profit organizations, universities. </p>
-        <p>Read more about it on the <a href="/grant-sponsors">FLOSS Pledge Page.</a></p></span>
-      </div>
-
-      <h2 id="using">USING HANDSHAKE</h2>
-      <div class="question">
-        <h3>How can trademark holders claim their names on HNS?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Handshake is holding a ninety day sunrise period before launch to allow existing rights-holders to claim their trademarked names. This is in order to help the seamless transition from a centralized root zone file to a decentralized root zone file. Read more in our Handshake Name Trademark Disclaimer. </p></span>
-      </div>
-      <div class="question">
-        <h3>Why is Handshake pre-reserving the top tens of thousands of domain names according to Alexa.com?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Existing TLDs and over 100,000 Alexa websites are reserved on the Handshake blockchain. Upon removing collisions, generic, and exclusions (e.g. 1 or 2 character names), approximately 80,000 names remain. Using the root key and DNSSEC, domain owners can cryptographically prove ownership to the Handshake blockchain to claim names. 100,000 was chosen as a number which the ownership is clear and has already gone through policy and process.</p></span>
-      </div>
-      <div class="question">
-        <h3>Why is Handshake allowing trademark holders to claim their names on HNS?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Handshake is holding a sunrise period before launch to allow existing rights-holders to claim their trademarked names. This is in order to help the seamless transition from a centralized root zone file to a decentralized root zone file. Read more in the <a href="/trademark-disclaimer">Handshake Name Trademark Disclaimer</a>.</p></span>
-      </div>
-      <div class="question">
-        <h3>What is the challenge with secure name resolution?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>The largest challenge is the “key exchange problem.” This can be solved by putting the certificate and names on the blockchain and tying their ownership to private keys. This is Handshake’s key innovation on the root zone file. </p></span>
-      </div>
-      <div class="question">
-        <h3>How do I register a Handshake name?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Handshake leverages a blockchain based on unspent transaction output (UTXO) and proof-of-work (PoW) similar to Bitcoin for naming capabilities. The naming system features an on-chain smart contract-like functionality called covenants which restrict the future use of outputs of a transaction. Because covenants are built in at the blockchain layer via the consensus protocol, the handshake system enables different types of smart contracts which is used to develop an auction system for individuals to bid on domain naming rights. </p></span>
-      </div>
-      <div class="question">
-        <h3>What does the Handshake names auction process look like?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Users can buy or register domains through a Vickrey auction using HNS coins. All possible names are released weekly over the first year after launch. Users may submit blinded bids on the Handshake blockchain anytime after a name is released for auction. Bidding is open to everyone for ~5 days after the reveal period, and have ~10 days to reveal their bid price. A winner is assigned the name and, as it is a Vickrey auction, pays the second highest bid at the end of the reveal period. The winning bid amount of HNS coins is burned and permanently removed from circulation. Losing bids are returned and not burned. </p></span>
-      </div>
-      <div class="question">
-        <h3>How long are my names good for?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Handshake names are registered for two years at a time. Names can be renewed biannually by paying a standard network fee. There are no social or technical guarantees with the renewability or ownership, this is an experimental system, please read the code to see details of how it currently works.</p></span>
-      </div>
-      <div class="question">
-        <h3>Who gets the renewal fee?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>Renewals for names are bi-annual and cost a standard network fee. Currently, miners will receive the transaction fee as part of their block reward.</p></span>
-      </div>
-      <div class="question">
-        <h3>How do I transfer ownership of a name?
-        <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
-        <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
-        <span><p>The name owner sends a TRANSFER transaction to the receiver, and that transaction is confirmed in a block on the blockchain. After 288 blocks (~2 days), the name owner can send a FINALIZE transaction. Once that is confirmed, the new owner controls the name. Transferring ownership may also have payments embedded, so the recipient will receive coins if and only if the transfer is successful. This means that users do not need to use 3rd party escrow to pay for transfer.</p></span>
-      </div>
-    </div>
-  </div></section>
-
-  </div> 
-</div> 
-
- 
-
-<footer id='footer'>
-<!-- the onboarding pages and dashboard use the small footer -->
-  
-    <div class='footer-wrap'>
-  <nav>
-    <div class='header'>
-      <h3>Handshake</h3>
-      <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-      <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-    </div>
-    <div class='links'>
-      <a href='/'>Home</a>
-      <a href='/community'>Community</a>
-    </div>
-  </nav>
-
-  <nav>
-    <div class='header'>
-      <h3>Learn</h3>
-      <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-      <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-    </div>
-    <div class='links'>
-      <a href='/faq'>FAQ</a>
-      <a href='/files/handshake.txt'>Design Notes</a>
-    </div>
-  </nav>
-
-  <nav>
-    <div class='header'>
-      <h3>Develop</h3>
-      <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-      <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-    </div>
-    <div class='links'>
-      <a href='https://handshake-org.github.io'>Documentation</a>
-      <a href='https://github.com/handshake-org/hsd'>Run a full node</a>
-      <a href='https://github.com/handshake-org/hnsd'>Install an SPV resolver</a>
-      <a href='https://handshake-org.github.io/guides/auctions.html'>Auction system guide</a>
-    </div>
-  </nav>
-
-  <!-- Keeps things in line -->
-  <nav style="display:none;">
-  </nav>
-</div><!-- close center-wrap -->
-
-
-
-  
-    <div class='footer-wrap bottom-wrap'>
-      <a href='/'>
-        Home
-      </a>
-      <a href='/terms-of-use'>
-        Terms of Use
-      </a>
-      <a href='/privacy-policy'>
-          Privacy Policy
-      </a>
-      <a href='/trademark-disclaimer'>
-          Trademark Disclaimer
-      </a>
-
-      <nav class='social-icons-small-footer'>
-        <a href='https://github.com/handshake-org/'>
-          <img src='/img/footer/github.svg' alt='GitHub logo'/>
+        <a class="nav-logo logo-link" href="/">
+          <img class='logo logo-light header-logo' src='/images/landing/logo-light.svg' alt="Handshake Logo" />
+          <img class='logo logo-dark header-logo' src='/images/landing/logo-dark.svg' alt="Handshake Logo" />
         </a>
-        <a href='https://twitter.com/hns'>
-          <img src='/img/footer/twitter.svg' alt='Twitter logo'/>
-        </a>
-        <a href='https://reddit.com/r/handshake'>
-          <img src='/img/footer/reddit.svg' alt='Reddit logo'/>
-        </a>
+
+        <div class="nav-right">
+          <div class="nav-links">
+            <ul>
+              <li><a href="/community" class="nav-item">Community</a></li>
+              <li><a href="https://handypedia.org" target="_blank" class="nav-item wiki-link">Wiki</a></li>
+              <li><a href="https://github.com/handshake-org" target="_blank" class="nav-item">GitHub</a></li>
+              <li><a href="https://handshake-org.github.io" class="nav-item">Docs</a></li>
+              <li><a href="/faq" class="nav-item">Faq</a></li>
+            </ul>
+          </div>
+        </div>
+
+        <button id="theme-toggle" style="background: none; border: 1px solid var(--accent-color); color: var(--accent-color); padding: 5px 15px; cursor: pointer; font-family: 'IBM Plex Mono', monospace;">
+            SWITCH MODE
+        </button>
       </nav>
-    </div>
-  
 
-</footer>
+      <div class="hero-content">
+        <h1>FAQ</h1>
+        <p class="subtitle">
+          There is no official Handshake Foundation or entity. Handshake is a decentralized protocol and loose consensus on its software.
+        </p>
+        <!-- editing out the buttons for now on Community page
+          <div class="hero-buttons">
+            <a href="https://handypedia.org/en/onboarding" target="_blank" class="btn-primary">Get Your Name</a>
+            <a href="https://handypedia.org" target="_blank" class="btn-secondary">Explore the Wiki</a>
+          </div>
+        -->
+      </div>
+    </header>
 
-<script src='/js/footer.js'></script>
-<script src='/js/nav.js'></script>
-<script>
-  window.addEventListener("load", function(e) {
-    document.documentElement.className = '';
-  });
-</script>
+    <div class="content">
+      <div class="wrapper">
+        <section id="faq" class="light">
+          <div class="section-wrapper faq">
+            <div id='navigation' class="links">
+              <a id='general-link' class='active' href="#general">General</a>
+              <a id='naming-link' href="#naming">Naming</a>
+              <a id='grants-link' href="#grants">Community Grants</a>
+              <a id='using-link' href="#using">Using Handshake</a>
+            </div>
+            <div id="questions">
 
-  <!--<script src='/js/faq.js'></script>
-  <script>
-  window.addEventListener("load", function(e) {
-    document.documentElement.className = '';
-  });
-</script>-->
+              <h2 id="general">GENERAL</h2>
+              <div class="question">
+                <h3>What does Handshake do?
+                <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+                <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+                <span><p>Handshake is an experiment on collaborating to create a decentralized network which results in a global allocation of names. Think of the handles or usernames you use on services such as social networks, and domain names identifying the URI for websites. Nearly all of these services were provided by trusted third parties which prevent the web from truly being decentralized. Handshake provides a means, including key management and server/service authentication, for decentralized web services to experiment. The Internet currently relies upon a single trust root DNS zone and an amalgamation of private companies providing trusted Certificate Authorities to secure the internet, Handshake is an experiment and exploration in alternatives. By providing a way to do decentralized lookup of name records, one can produce hashes and keys to identify resources over decentralized networks without a trusted Certificate Authority corporation.</p></span>
+              </div>
+              <div class="question">
+                <h3>Why is canonicalization of naming within namespaces important?
+                <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+                <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+                <span><p>Having a unique name on a particular namespace or zone is incredibly important for the security of the internet. Having a decentralized unique namespace could enable decentralized internet technologies. If you have a username on a social network, you may want a unique URI to view your profile. Similarly, for domain TLDs and other resources, it is helpful to know that you're correctly communicating with the desired endpoint. Without a unique namespace, the internet is vulnerable to either everyone having to type in the cryptographic key (making name lack usefulness), or a lack of agreement on the relationship between a resource and name. This has very severe security implications. Handshake's <a href="https://en.wikipedia.org/wiki/Zooko%27s_triangle">goal</a> is decentralization, canonicalization of names, <b>and</b> security. With the root zone in use as of the time of this writing (2019), internet naming does not provide decentralization, nor secure authenticated canonicalization of names (the Certificate Authority system).</p></span>
+              </div>
+              <div class="question">
+                <h3>How does Handshake work?
+                <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+                <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+                <span><p>Handshake needs to reach global agreement on names and its owners. To do this, we need to develop ordering of when a name has already been registered in a decentralized way. In essence, we need decentralized global agreement on ordering. Handshake uses its own blockchain to do so. While there has been much misunderstanding on the purpose of a blockchain, the purpose is primarily to ordering events which occur over time (did A happen before B?). If no ordering of events are necessary, a blockchain is not needed. The Handshake blockchain creates an ordering of name registrations, so one knows when a name has already been registered. Without a global decentralized agreement on the order of registrations, we cannot know whether Alice owns the name or Bob does (did Bob make a false claim of registration after Alice already made one). Handshake has everyone run the same software rules so everyone can programmatically come to agreement on name ownership. When a name is registered, the owner has a cryptographic key which is under their control, which assigns ownership to themselves, and can write records on Handshake which identifies, authorizes, and locates resources associated with their name. As these records are also ordered, one can have greater assurance on whether the records are expired or current.</p></span>
+              </div>
+              <div class="question">
+                <h3>Does this promote carbon emissions?
+                <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+                <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+                <span><p>Handshake uses proof-of-work mining, as it is currently the most reliable way to do compact light client proofs. Proof of work uses computational power, a lot of it. However, the overwhelming majority of this computational power is produced using renewables, currently wind and hydro. The reason proof-of-work is currently primarily renewables is that the competitive cost has driven down to places with <i>excess</i> energy, which are remote hydro and wind farms. While there are no guarantees this will persist, the percentage which uses renewables is increasing. In the future, it is possible to have it be a contributor to subsidizing off-grid solar power. As the grid becomes less viable due to local generation, it is possible that miners securing the network can provide an additional revenue stream. This isn't certain, but a theory is that if mining is secured by solar, the network security would be much higher, as that would mean that it requires significant investment in physical infrastructure to attack. This benefits people with off-grid solar panels, as their electricity is otherwise worthless after their batteries are fully charged. While it is uncertain if this will prove to be the case and alternatives should be ready, currently the overwhelming majority of proof of work mining using renewables is increasing.</p></span>
+              </div>
+              <div class="question">
+                <h3>When is the first handshake?
+                <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+                <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+                <span><p>On the 615817th Bitcoin block height, the BTC blockhash will be committed into the Handshake genesis block. While it can be immediately mined, the genesis block is only locked in after six confirmations. After the first six confirmations of valid Bitcoin blocks, the genesis block will not change, even with a deep reorg. The code is available for <a href="/download">download</a>. Transactions will enabled after two weeks worth of blocks.
+                </p></span>
+              </div>
+
+              <h2 id="naming">NAMING</h2>
+              <div class="question">
+                <h3>How do Internet names currently work?
+                <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+                <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+                <span><p>When a domain name is resolved to a corresponding server in the IP space, it uses a recursive DNS resolver such as Google's Public DNS server. DNS servers query a number of root servers maintained by one of 12 centralized entities. These root servers serve the "root zone". The root zone is the collection of Top Level Domains (TLDs) like .com, .net, .org, etc. </p></span>
+              </div>
+              <div class="question">
+                <h3>Why does the Certificate Authority system benefit from decentralization?
+                <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+                <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+                <span><p>Compromised certificate authorities threaten SSL. Billions of dollars are currently being moved around on potentially insecure websites. If you’re personally identifiable as the owner of a valuable asset, there’s a risk to your personal safety. Even though WHOIS records have been scrubbed of private information — with the current naming system, your information can still be subpoenaed from a domain registrar. </p></span>
+              </div>
+              <div class="question">
+                <h3>What issues have occured with the centralized nature of the root zone and DNS as it currently stands?
+                <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+                <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+                <span><p>Certificate authorities and private owners of TLDs impose fees while often compromising the security of SSL by issuing bad certificates or cooperating with government attempts to spy on encrypted traffic or censor undesirable content. One common mechanism of Internet censorship that has been used with increasing and alarming frequency is DNS filtering and redirection. Another area where the centralized nature of Internet names has come to a head is domain registration privacy. Additionally, the way DNS is currently centered at a handful of choke points allows for DDoS attacks like we saw in the 2016 attack on Dyn. </p></span>
+              </div>
+              <div class="question">
+                <h3>Does Handshake replace DNS?
+                <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+                <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+                <span><p>No. Handshake is meant to replace the root zone file, not DNS. Browsing the web with human readable names is what Internet users have gotten acclimated to. Our solution allows for a seamless transition between a centralized name root zone file controlled by  private parties to a decentralized root zone file controlled by actual Internet users. The Handshake blockchain itself is essentially one big distributed zone file in which anyone has the right to add an entry in. </p></span>
+              </div>
+            <div class="question">
+              <h3>What can you do with Handshake and DNS now?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>Using OpenSSH, it’s possible to store SSH fingerprints in DNS. This means that if you're using a Handshake Name System (HNS) resolver, you can actually already verify SSH fingerprints in a decentralized way. This is possible without needing to install any additional, special SSH software. </p> <p>DNS has an additional feature that allows you to verify TLS certificates by storing a hash of your ‘SubjectPublicKeyInfo’. This means that there is now a P2P way to trust self-signed certificates, as long as they have a valid DNSSEC trust chain set up. Anyone can set up a valid trust chain without having to ask anyone's permission to do so. </p></span>
+            </div>
+            <div class="question">
+              <h3>How is Handshake different from other decentralized naming projects?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>Many other decentralized naming systems did not allow for secure “light clients” (simple payment verification mode), forcing every potential user to run a full node, equivalent to saving all the domains in the world on your computer. Another key differentiator is that Handshake is the first to pre-reserve names for existing trademark name holders. </p></span>
+            </div>
+
+            <h2 id="grants">COMMUNITY GRANTS</h2>
+            <div class="question">
+              <h3>Why is there a grant of $10.2 million to nonprofits and free/open source projects?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>Handshake’s original incubators, Purse.io and Private Internet Access, provided enough support to build and launch the platform without additional funding. The pre-launch project contributors don’t require additional capital from subsequent investors, but what was needed is their deep expertise in early stage technology venture valuation. Accepting their investment at mutually agreed upon terms ensures Handshake launches at a reasonable valuation and enables the network to immediately bootstrap the decentralized market for Internet names. Beyond that Handshake has everything needed and that capital is better deployed by the FOSS organizations to which have been pledged to contribute it.
+              </p></span>
+            </div>
+            <div class="question">
+              <h3>Why are free and open source contributors receiving the majority of the initial HNS?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>The Internet, and civilization as a whole, would not be where it is today without the hard work of the free software and open source community and the projects that they work on. The Handshake blockchain will start with an initial supply of 1.36 billion coins, of which ~67.5% will be gifted to FLOSS developers and projects, as well as non profit organizations, universities. </p>
+              <p>Read more about it on the <a href="/grant-sponsors">FLOSS Pledge Page.</a></p></span>
+            </div>
+
+            <h2 id="using">USING HANDSHAKE</h2>
+            <div class="question">
+              <h3>How can trademark holders claim their names on HNS?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>Handshake is holding a ninety day sunrise period before launch to allow existing rights-holders to claim their trademarked names. This is in order to help the seamless transition from a centralized root zone file to a decentralized root zone file. Read more in our Handshake Name Trademark Disclaimer. </p></span>
+            </div>
+            <div class="question">
+              <h3>Why is Handshake pre-reserving the top tens of thousands of domain names according to Alexa.com?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>Existing TLDs and over 100,000 Alexa websites are reserved on the Handshake blockchain. Upon removing collisions, generic, and exclusions (e.g. 1 or 2 character names), approximately 80,000 names remain. Using the root key and DNSSEC, domain owners can cryptographically prove ownership to the Handshake blockchain to claim names. 100,000 was chosen as a number which the ownership is clear and has already gone through policy and process.</p></span>
+            </div>
+            <div class="question">
+              <h3>Why is Handshake allowing trademark holders to claim their names on HNS?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>Handshake is holding a sunrise period before launch to allow existing rights-holders to claim their trademarked names. This is in order to help the seamless transition from a centralized root zone file to a decentralized root zone file. Read more in the <a href="/trademark-disclaimer">Handshake Name Trademark Disclaimer</a>.</p></span>
+            </div>
+            <div class="question">
+              <h3>What is the challenge with secure name resolution?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>The largest challenge is the “key exchange problem.” This can be solved by putting the certificate and names on the blockchain and tying their ownership to private keys. This is Handshake’s key innovation on the root zone file. </p></span>
+            </div>
+            <div class="question">
+              <h3>How do I register a Handshake name?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>Handshake leverages a blockchain based on unspent transaction output (UTXO) and proof-of-work (PoW) similar to Bitcoin for naming capabilities. The naming system features an on-chain smart contract-like functionality called covenants which restrict the future use of outputs of a transaction. Because covenants are built in at the blockchain layer via the consensus protocol, the handshake system enables different types of smart contracts which is used to develop an auction system for individuals to bid on domain naming rights. </p></span>
+            </div>
+            <div class="question">
+              <h3>What does the Handshake names auction process look like?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>Users can buy or register domains through a Vickrey auction using HNS coins. All possible names are released weekly over the first year after launch. Users may submit blinded bids on the Handshake blockchain anytime after a name is released for auction. Bidding is open to everyone for ~5 days after the reveal period, and have ~10 days to reveal their bid price. A winner is assigned the name and, as it is a Vickrey auction, pays the second highest bid at the end of the reveal period. The winning bid amount of HNS coins is burned and permanently removed from circulation. Losing bids are returned and not burned. </p></span>
+            </div>
+            <div class="question">
+              <h3>How long are my names good for?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>Handshake names are registered for two years at a time. Names can be renewed biannually by paying a standard network fee. There are no social or technical guarantees with the renewability or ownership, this is an experimental system, please read the code to see details of how it currently works.</p></span>
+            </div>
+            <div class="question">
+              <h3>Who gets the renewal fee?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>Renewals for names are bi-annual and cost a standard network fee. Currently, miners will receive the transaction fee as part of their block reward.</p></span>
+            </div>
+            <div class="question">
+              <h3>How do I transfer ownership of a name?
+              <span><footer class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded answer on mobile'/></span>
+              <span class='hide'><footer class='footer-caret-up' src='/img/footer/up-caret.svg' alt='Toggle expanded answer on mobile'/></span></h3>
+              <span><p>The name owner sends a TRANSFER transaction to the receiver, and that transaction is confirmed in a block on the blockchain. After 288 blocks (~2 days), the name owner can send a FINALIZE transaction. Once that is confirmed, the new owner controls the name. Transferring ownership may also have payments embedded, so the recipient will receive coins if and only if the transfer is successful. This means that users do not need to use 3rd party escrow to pay for transfer.</p></span>
+            </div>
+          </div>
+        </section>
+      </div> 
+    </div> 
+
+     
+
+    <footer id='footer'>
+    <!-- the onboarding pages and dashboard use the small footer -->
+      
+      <div class='footer-wrap'>
+        <nav>
+          <div class='header'>
+            <h3>Handshake</h3>
+            <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+            <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+          </div>
+          <div class='links'>
+            <a href='/'>Home</a>
+            <a href='/community'>Community</a>
+          </div>
+        </nav>
+
+        <nav>
+          <div class='header'>
+            <h3>Learn</h3>
+            <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+            <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+          </div>
+          <div class='links'>
+            <a href='/faq'>FAQ</a>
+            <a href='/files/handshake.txt'>Design Notes</a>
+          </div>
+        </nav>
+
+        <nav>
+          <div class='header'>
+            <h3>Develop</h3>
+            <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+            <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+          </div>
+          <div class='links'>
+            <a href='https://handshake-org.github.io'>Documentation</a>
+            <a href='https://github.com/handshake-org/hsd'>Run a full node</a>
+            <a href='https://github.com/handshake-org/hnsd'>Install an SPV resolver</a>
+            <a href='https://handshake-org.github.io/guides/auctions.html'>Auction system guide</a>
+          </div>
+        </nav>
+
+        <!-- Keeps things in line -->
+        <nav style="display:none;">
+        </nav>
+      </div><!-- close center-wrap -->
 
 
-</body>
+      <div class='footer-wrap bottom-wrap'>
+        <a href='/'>
+          Home
+        </a>
+        <a href='/terms-of-use'>
+          Terms of Use
+        </a>
+        <a href='/privacy-policy'>
+            Privacy Policy
+        </a>
+        <a href='/trademark-disclaimer'>
+            Trademark Disclaimer
+        </a>
+
+        <nav class='social-icons-small-footer'>
+          <a href='https://github.com/handshake-org/'>
+            <img src='/img/footer/github.svg' alt='GitHub logo'/>
+          </a>
+          <a href='https://twitter.com/hns'>
+            <img src='/img/footer/twitter.svg' alt='Twitter logo'/>
+          </a>
+          <a href='https://reddit.com/r/handshake'>
+            <img src='/img/footer/reddit.svg' alt='Reddit logo'/>
+          </a>
+        </nav>
+      </div>
+    </footer>
+
+    <script src='/js/footer.js'></script>
+    <script src='/js/nav.js'></script>
+    <script>
+      window.addEventListener("load", function(e) {
+        document.documentElement.className = '';
+      });
+    </script>
+
+    <script>
+      // Manual toggle for the mobile menu
+      document.getElementById('nav-toggle').addEventListener('click', function() {
+        document.getElementById('burgernav').classList.toggle('open');
+        document.getElementById('overlay').classList.toggle('open');
+      });
+
+      // Close the menu if you click the overlay
+      document.getElementById('overlay').addEventListener('click', function() {
+        document.getElementById('burgernav').classList.remove('open');
+        document.getElementById('overlay').classList.remove('open');
+      });
+    </script>
+
+    <script>
+      // 1. REVEAL EFFECT (Keep this!)
+      const observerOptions = { threshold: 0.1 };
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('active');
+          }
+        });
+      }, observerOptions);
+
+      document.querySelectorAll('.reveal, section').forEach(el => {
+        observer.observe(el);
+      });
+
+      // --- THEME TOGGLE LOGIC ---
+      const themeToggle = document.getElementById('theme-toggle');
+      const htmlElement = document.documentElement;
+
+      function applyTheme(theme) {
+        const isDark = theme === 'dark';
+        htmlElement.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        
+        if (themeToggle) {
+          themeToggle.innerText = isDark ? 'LIGHT MODE' : 'DARK MODE';
+          // Use the variables directly or hardcode them to match the theme
+          themeToggle.style.borderColor = isDark ? '#00ff41' : '#0033ff';
+          themeToggle.style.color = isDark ? '#00ff41' : '#0033ff';
+        }
+      }
+
+      const savedTheme = localStorage.getItem('theme') || 'dark';
+      applyTheme(savedTheme);
+
+      if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+          const newTheme = htmlElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+          applyTheme(newTheme);
+        });
+      }
+
+      // Trigger once on load to set initial positions
+      window.dispatchEvent(new Event('scroll'));
+    </script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,289 +1,357 @@
 <!DOCTYPE html>
 
 <html lang='en'>
-<head>
+  <head>
 
-  <title>Handshake</title>
+    <title>Handshake</title>
 
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-  <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
-	<meta name="description" content="Decentralized certificate authority and naming" />
-	<meta property="og:title" content="Handshake" />
-	<meta property="og:description" content="Decentralized certificate authority and naming" />
-	<meta property="og:url" content="https://handshake.org" />
-	<meta property="og:image" content="https://www.handshake.org/images/landing/logo-dark.svg" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
+    <meta name="description" content="Decentralized certificate authority and naming" />
+    <meta property="og:title" content="Handshake" />
+    <meta property="og:description" content="Decentralized certificate authority and naming" />
+    <meta property="og:url" content="https://handshake.org" />
+    <meta property="og:image" content="https://www.handshake.org/images/landing/logo-dark.svg" />
 
-  <link rel="shortcut icon" href="/img/favicon/hns-favicon.ico" type="image/x-icon">
-  <link rel="stylesheet" type="text/css" href="css/fonts/nitti.css" />
-  <link rel="stylesheet" type="text/css" href="css/fonts/ibmplexmono.css" />
-  <link rel="stylesheet" type="text/css" href="css/fonts/ibmplexsans.css" />
-  <link rel="stylesheet" type="text/css" href="css/footer.css"/>
+    <link rel="shortcut icon" href="/img/favicon/hns-favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" type="text/css" href="/css/fonts/nitti.css" />
+    <link rel="stylesheet" type="text/css" href="/css/fonts/ibmplexmono.css" />
+    <link rel="stylesheet" type="text/css" href="/css/fonts/ibmplexsans.css" />
+    <link rel="stylesheet" type="text/css" href="/css/footer.css"/>
 
-  
-    <link rel="stylesheet" type="text/css" href="css/marketing.css" />
-  
-  <style type="text/css">
-    .no-fouc {display: none;}
-</style>
+    <link rel="stylesheet" type="text/css" href="/css/marketing.css" />
+    <link rel="stylesheet" type="text/css" href="/css/refresh.css" />
 
-<script type="text/javascript">
-    document.documentElement.className = 'no-fouc';
-</script>
+  </head>
 
-</head>
+  <body class="landing">
 
-<body class="landing">
-
-  <header><div class="header-wrapper"><div class="inner-wrapper">
-    <nav id="navBar" class="no-js nav-bar">
-
-  
-    <div id='nav-toggle' class="burgermenu" href="#">☰</div>
-
-    <div id='overlay'></div>
-    <div id="burgernav">
-      <ul>
-
-          <li><a href="https://handshake-org.github.io">Documentation</a></li>
-          <li><a href="/community">Community</a></li>
-          <li><a href="/faq">Faq</a></li>
-          
-          
-      </ul>
-    </div>
-  
-
-  <a class="nav-logo" href="/">
-    <img class='logo logo-dark' src='/images/landing/logo-dark.svg' /><img class='logo logo-light' src='/images/landing/logo-light.svg' />
-  </a>
-
-  
-    <div class="nav-right ">
-      <div class="nav-links "">
+    <header class="hero-section">
+      <nav id="navBar" class="nav-container no-js nav-bar">
+        
+        <div id='nav-toggle' class="burgermenu">☰</div>
+        <div id='overlay'></div>
+        
+        <div id="burgernav">
           <ul>
-            
-
-              <li><a href="https://handshake-org.github.io">Documentation</a></li>
-              <li><a href="/community">Community</a></li>
-              <li><a href="/faq">Faq</a></li>
-              
-              
-            
+            <li><a href="/community">Community</a></li>
+            <li><a href="https://handypedia.org" target="_blank">Wiki</a></li>
+            <li><a href="https://github.com/handshake-org" target="_blank">GitHub</a></li>
+            <li><a href="https://handshake-org.github.io">Docs</a></li>
+            <li><a href="/faq">Faq</a></li>
           </ul>
         </div>
-        
-        
-      </div>
-  
-</nav>
 
-  </div></div></header>
-  <div class="content">
-    <div class="wrapper">
-      
+        <a class="nav-logo logo-link" href="/">
+          <img class='logo logo-light header-logo' src='/images/landing/logo-light.svg' alt="Handshake Logo" />
+          <img class='logo logo-dark header-logo' src='/images/landing/logo-dark.svg' alt="Handshake Logo" />
+        </a>
 
-
-  <section class="light"><div class="section-wrapper"><div class="columns">
-    <div>
-      <h1>Decentralized naming and certificate authority</h1>
-      <h3>An experimental peer-to-peer root naming system.</h3>
-    </div>
-    <div>
-      <div class='hero-info'>
-        <p>
-          <strong>Source Code:</strong>
-          Multiple implementations may exist. Initial code: <a href='https://github.com/handshake-org/hsd'>GitHub</a>, <a href="/download">Download</a>
-        </p>
-      </div>
-      <div class='hero-info'>
-        <p>
-          <strong>GUI Full Node Wallet:</strong>
-          <a href="https://bobwallet.io/">Bob Wallet</a>, <a href="https://github.com/kyokan/bob-wallet">Source Code</a>
-        </p>
-      </div>
-      <div class='hero-info'>
-        <p>
-          <strong>Claim HNS for FOSS developers:</strong>
-            <br><a href='/claim'>Claim here</a> and register names.
-            <p style="font-size:12px">Please be careful when using other software to claim.</p>
-        </p>
-      </div>
-      <div class='hero-info'>
-        <p>
-          <strong>Technical Info:</strong>
-          <a href='https://github.com/handshake-org/hsd'>Install</a>, <a href='files/handshake.txt'>Design notes</a>, <a href='https://handshake-org.github.io'>Docs</a>.
-        </p>
-      </div>
-      <div class='hero-info'>
-      	<p>
-          <strong>Telegram:</strong>
-          <a href='https://t.me/handshake_hns'>@handshake_hns</a>
-        </p>
-      	<p>
-          <strong>Discord:</strong>
-          <a href='/discord'>handshake on Discord</a>
-        </p>
-        <p>
-          <strong>IRC:</strong>
-          <a href='https://web.libera.chat#handshake'>#handshake on Libera Chat</a>
-        </p>
-         <p>
-          <strong>Matrix↔IRC Bridge:</strong>
-          <a href='https://matrix.to/#/#handshake:libera.chat'>#handshake:libera.chat</a>
-        </p>
-      </div>
-    </div>
-  </div></div></section>
-
-  <section id="about" class="default"><div class="section-wrapper"><div class="columns">
-    <div>
-      <h2>ABOUT HANDSHAKE</h2>
-<p>Handshake is a decentralized, permissionless naming protocol where every peer is validating and in charge of managing the root DNS naming zone with the goal of creating an alternative to existing Certificate Authorities and naming systems. Names on the internet (top level domains, social networking handles, etc.) ultimately rely upon centralized actors with full control over a system which are relied upon to be honest, as they are vulnerable to hacking, censorship, and corruption. Handshake aims to experiment with new ways the internet can be more secure, resilient, and socially useful with a peer-to-peer system validated by the network's participants.</p>
-      <p>Handshake is an experiment which seeks to explore those new ways in which the necessary tools to build a more decentralized internet. Services on the internet have become more centralized beginning in the 1990s, but do not fulfill the original decentralized vision of the internet. <b><!--<span style="color:#693AFA">-->Email became Gmail, usenet became reddit, blog replies became facebook and Medium, pingbacks became twitter, squid became Cloudflare, even gnutella became The Pirate Bay<!--</span>--></b>. Centralization exists because there is a need to manage spam, griefing, and sockpuppet/sybil attacks. Previous decentralized systems largely stopped working due to spam. If it were more costly to grief on the internet using decentralized systems, the need for trusted centralized corporations to manage these risks decrease. Internet services and platforms may benefit from building on top of a decentralized system which is specifically designed for resilience against sybil attacks.<br>As we may redecentralize.</p>
-    </div>
-
-    <div>
-      <img src="images/landing/blocks.svg" alt="Web of Network Nodes" width="430px"/>
-    </div>
-  </div></div></section>
-
-  <section class="light"><div class="section-wrapper"><div>
-    <h2>THE HANDSHAKE PROTOCOL</h2>
-
-    <p>By running Handshake, one can participate in a decentralized open naming platform secured by a decentralized peer-to-peer network.
-    <p>Read the <a href='files/handshake.txt'>project design notes</a><br>
-      Documentation <a href='https://handshake-org.github.io'>here</a><br>
-      Initial code on <a href='https://github.com/handshake-org'>GitHub</a>
-    </p>
-
-    <ul class="notes">
-      <li><b>A base layer for the decentralized internet</b>. The internet is arranged in layers, to decentralize the internet, we need to start at the lowest layers of the stack. Secure naming ensures user agents are talking to the right endpoints.</li>
-      <li><b>The place for minimal global consensus</b>. Decentralization is most successful if we have minimal areas to reach complete global agreement. Names and signing certificates may be one of the few (if only) places of global agreement for a decentralized web. Handshake is an experimental structure for reaching that agreement via software.</li>
-      <li><b>True decentralization</b>, no official singular Foundation, Committee, Corporation, or entities in permanent unitary control of the protocol.</li>
-      <li><b>Economic incentives</b> enable decentralized agreements to form via a transparent name auction process. Without some kind of economic cost function, one person could register all names. Economic incentives enable decentralized sybil resistance which would otherwise be centralized and corrupted.
-      <li><b>Alternative to certificate authorities</b>, using a decentralized trust anchor to prove domain ownership</li>
-      <li><b>Distributed and permissionless</b> zone file to which any participant has the right to add an entry or serve as host and validator</li>
-      <li><b>Light clients</b> via merkelized proofs and proof-of-work allow for lightweight name resolutions and certificates. The initial protocol enables cryptographic name proofs, with the potential for decentralized proof lookups to be usually within the MTU limit.</li>
-      <li><b>A platform for sybil resilience</b>.  WoT can/should be used as an augmentation, but it is often not a global agreement of resources for individual decentralized services. By using Handshake names, one can know that some kind of economic limits exist for the use of the name. This can be leveraged whenever one is concerned about resource exhaustion, and reaching global agreement on moderation alone is too costly.</li>
-    </ul>
-  </div></div></section>
-
-  <section class="default"><div class="section-wrapper"><div class="columns">
-    <div>
-      <h2>INTERNET NAME TRANSFERS USING COINS TO PREVENT SYBIL ATTACKS</h2>
-      <p>Handshake is a piece of software (and a loose consensus on agreement of the software itself). This software's primary function is for people to come to agreement on names and cryptographic keys authorized to represent that names in a decentralized way. To do this in a decentralized way, we need to prevent a single party from claiming all the names. Therefore, a unit of account is needed to prevent that single party from claiming all names.</p>
-      <p>Handshake uses a coin system for name registration. The Handshake coin (HNS) is the mechanism by which participants transfer, register, and update internet names. The community will be able to initiate auctions and place bids for top-level domains using HNS or trade their HNS as they see fit, with differing value per name.</p>
-      <p>Therefore, Handshake allocates the majority of its initial coins towards the FOSS community with absolutely no obligation attached, as it is this community most relevant with decentralized software and tools. The goal of the initial design was to account for all possible stakeholders. <a href="/grant-sponsors">More info</a>.</p>
-      <p>Handshake's incentive design assumptions relies upon Metcalfe's Law (Beckstrom's Law, etc.). While Bitcoin's value is derived from it being a costly store of value, Handshake's value is derived from its network of users. Metcalfe's Law asserts that an increase in userbase increases the value of the network (sub)exponentially. This means that allocation of value to potential developers and users of this system be a benefit to everyone, with network effect derived benefiting all users.</p>
-    </div>
-    <div>
-      <div class='faucet-cta'>
-          <h3>Free and Open Source Developers</h3>
-        <div class='columns'>
-          <p>Majority ownership of HNS can be claimed by Free and Open Source Software contributors directly to the network itself on-chain. <a href='/claim'> Read more here.</a></p>
+        <div class="nav-right">
+          <div class="nav-links">
+            <ul>
+              <li><a href="/community" class="nav-item">Community</a></li>
+              <li><a href="https://handypedia.org" target="_blank" class="nav-item wiki-link">Wiki</a></li>
+              <li><a href="https://github.com/handshake-org" target="_blank" class="nav-item">GitHub</a></li>
+              <li><a href="https://handshake-org.github.io" class="nav-item">Docs</a></li>
+              <li><a href="/faq" class="nav-item">Faq</a></li>
+            </ul>
           </div>
-        <div class='columns'>
-          <p>Top github users and PGP WoT Strong Set are the primary set (along with several other communities). This list is <b>not</b> a "toplist of FOSS developers and advocates" and inclusion does not imply that one is a top contributor, this was a list optimized towards availability of scrapeable unique public keys, as the keys are claimed in a decentralized way after the list was generated, and cannot be modified after Handshake goes live without a subsequent hard-fork allocation.</p>
         </div>
-        </p>
-      </div>
-    </div>
-  </div></div></section>
 
-  </div> 
-</div> 
-
-
-
-<footer id='footer'>
-<!-- the onboarding pages and dashboard use the small footer -->
-  
-    <div class='footer-wrap'>
-  <nav>
-    <div class='header'>
-      <h3>Handshake</h3>
-      <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-      <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-    </div>
-    <div class='links'>
-      <a href='/'>Home</a>
-      <a href='/community'>Community</a>
-    </div>
-  </nav>
-
-  <nav>
-    <div class='header'>
-      <h3>Learn</h3>
-      <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-      <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-    </div>
-    <div class='links'>
-      <a href='/faq'>FAQ</a>
-      <a href='/files/handshake.txt'>Design Notes</a>
-    </div>
-  </nav>
-
-  <nav>
-    <div class='header'>
-      <h3>Develop</h3>
-      <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-      <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
-    </div>
-    <div class='links'>
-      <a href='https://handshake-org.github.io'>Documentation</a>
-      <a href='https://github.com/handshake-org/hsd'>Run a full node</a>
-      <a href='https://github.com/handshake-org/hnsd'>Install an SPV resolver</a>
-      <a href='https://handshake-org.github.io/guides/auctions.html'>Auction system guide</a>
-    </div>
-  </nav>
-
-  <!-- Keeps things in line -->
-  <nav style="display:none;">
-  </nav>
-</div><!-- close center-wrap -->
-
-
-
-  
-    <div class='footer-wrap bottom-wrap'>
-      <a href='/'>
-        Home
-      </a>
-      <a href='/terms-of-use'>
-        Terms of Use
-      </a>
-      <a href='/privacy-policy'>
-          Privacy Policy
-      </a>
-      <a href='/trademark-disclaimer'>
-          Trademark Disclaimer
-      </a>
-
-      <nav class='social-icons-small-footer'>
-        <a href='https://github.com/handshake-org/'>
-          <img src='/img/footer/github.svg' alt='GitHub logo'/>
-        </a>
-        <a href='https://twitter.com/hns'>
-          <img src='/img/footer/twitter.svg' alt='Twitter logo'/>
-        </a>
-        <a href='https://reddit.com/r/handshake'>
-          <img src='/img/footer/reddit.svg' alt='Reddit logo'/>
-        </a>
+        <button id="theme-toggle" style="background: none; border: 1px solid var(--accent-color); color: var(--accent-color); padding: 5px 15px; cursor: pointer; font-family: 'IBM Plex Mono', monospace;">
+            SWITCH MODE
+        </button>
       </nav>
-    </div>
-  
 
-</footer>
+      <div class="hero-content">
+        <span class="protocol-status">PROTOCOL MAINNET STABLE</span>
+        <h1>The Decentralized <br><span class="accent">Root</span> of the Internet</h1>
+        <p class="subtitle">
+          Handshake is a sovereign, peer-to-peer root naming system. 
+          Owned by the people, secured by the blockchain, and 
+          built to replace the centralized gatekeepers of the web.
+        </p>
+        <div class="hero-buttons">
+          <a href="https://handypedia.org/en/onboarding" target="_blank" class="btn-primary">Get Your Name</a>
+          <a href="https://handypedia.org" target="_blank" class="btn-secondary">Explore the Wiki</a>
+        </div>
+      </div>
+    </header>
 
-<script src='/js/footer.js'></script>
-<script src='/js/nav.js'></script>
-<script>
-  window.addEventListener("load", function(e) {
-    document.documentElement.className = '';
-  });
-</script>
- 
+    <div class="content">
+      <div class="wrapper">
 
-</body>
+        <section class="light" id="info">
+          <div class="section-content light-bg">
+            <div class="section-wrapper">
+              <div class="columns">
+                <div>
+                  <h1>Decentralized naming and certificate authority</h1>
+                  <h3>A revolutionary peer-to-peer root naming system.</h3>
+                </div>
+                <div>
+                  <div class='hero-info'>
+                    <p>
+                      <strong>Source Code:</strong>
+                      Multiple implementations may exist. Initial code: <a href='https://github.com/handshake-org/hsd'>GitHub</a>, <a href="/download">Download</a>
+                    </p>
+                  </div>
+                  <div class='hero-info'>
+                    <p>
+                      <strong>GUI Full Node Wallet:</strong>
+                      <a href="https://bobwallet.io/">Bob Wallet</a>, <a href="https://github.com/kyokan/bob-wallet">Source Code</a>
+                    </p>
+                  </div>
+                  <div class='hero-info'>
+                    <p>
+                      <strong>Claim HNS for FOSS developers:</strong>
+                        <br><a href='/claim'>Claim here</a> and register names.
+                        <p style="font-size:12px">Please be careful when using other software to claim.</p>
+                    </p>
+                  </div>
+                  <div class='hero-info'>
+                    <p>
+                      <strong>Technical Info:</strong>
+                      <a href='https://github.com/handshake-org/hsd'>Install</a>, <a href='files/handshake.txt'>Design notes</a>, <a href='https://handshake-org.github.io'>Docs</a>.
+                    </p>
+                  </div>
+                  <div class='hero-info'>
+                    <p>
+                      <strong>Telegram:</strong>
+                      <a href='https://t.me/handshake_hns'>@handshake_hns</a>
+                    </p>
+                    <p>
+                      <strong>Discord:</strong>
+                      <a href='/discord'>handshake on Discord</a>
+                    </p>
+                    <p>
+                      <strong>IRC:</strong>
+                      <a href='https://web.libera.chat#handshake'>#handshake on Libera Chat</a>
+                    </p>
+                     <p>
+                      <strong>Matrix↔IRC Bridge:</strong>
+                      <a href='https://matrix.to/#/#handshake:libera.chat'>#handshake:libera.chat</a>
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="default" id="about">
+          <div class="section-content default-bg">
+            <div class="section-wrapper">
+              <div class="columns">
+                <div>
+                  <h2>ABOUT HANDSHAKE</h2>
+                  <p>Handshake is a decentralized, permissionless naming protocol where every peer is validating and in charge of managing the root DNS naming zone with the goal of creating an alternative to existing Certificate Authorities and naming systems. Names on the internet (top level domains, social networking handles, etc.) ultimately rely upon centralized actors with full control over a system which are relied upon to be honest, as they are vulnerable to hacking, censorship, and corruption. Handshake aims to make the internet more secure, resilient, and socially useful with a peer-to-peer system validated by the network's participants.</p>
+                  <p>Handshake seeks to establish the necessary tools to build a more decentralized internet. Services on the internet have become more centralized beginning in the 1990s, but do not fulfill the original decentralized vision of the internet. <b>Email became Gmail, usenet became reddit, blog replies became facebook and Medium, pingbacks became twitter, squid became Cloudflare, even gnutella became The Pirate Bay</b>. Centralization exists because there is a need to manage spam, griefing, and sockpuppet/sybil attacks. Previous decentralized systems largely stopped working due to spam. If it were more costly to grief on the internet using decentralized systems, the need for trusted centralized corporations to manage these risks decrease. Internet services and platforms may benefit from building on top of a decentralized system which is specifically designed for resilience against sybil attacks.<br>As we may redecentralize.</p>
+                </div>
+                <div>
+                  <img src="images/landing/blocks.svg" alt="Web of Network Nodes" width="430px" class="img-fluid"/>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="light" id="protocol">
+          <div class="section-content light-bg">
+            <div class="section-wrapper">
+              <div>
+                <h2>THE HANDSHAKE PROTOCOL</h2>
+
+                <p>By running Handshake, one can participate in a decentralized open naming platform secured by a decentralized peer-to-peer network.
+                <p>Read the <a href='files/handshake.txt'>project design notes</a><br>
+                  Documentation <a href='https://handshake-org.github.io'>here</a><br>
+                  Initial code on <a href='https://github.com/handshake-org'>GitHub</a>
+                </p>
+
+                <ul class="notes">
+                  <li><b>A base layer for the decentralized internet</b>. The internet is arranged in layers, to decentralize the internet, we need to start at the lowest layers of the stack. Secure naming ensures user agents are talking to the right endpoints.</li>
+                  <li><b>The place for minimal global consensus</b>. Decentralization is most successful if we have minimal areas to reach complete global agreement. Names and signing certificates may be one of the few (if only) places of global agreement for a decentralized web. Handshake is a structure for reaching that agreement via software.</li>
+                  <li><b>True decentralization</b>, no official singular Foundation, Committee, Corporation, or entities in permanent unitary control of the protocol.</li>
+                  <li><b>Economic incentives</b> enable decentralized agreements to form via a transparent name auction process. Without some kind of economic cost function, one person could register all names. Economic incentives enable decentralized sybil resistance which would otherwise be centralized and corrupted.
+                  <li><b>Alternative to certificate authorities</b>, using a decentralized trust anchor to prove domain ownership</li>
+                  <li><b>Distributed and permissionless</b> zone file to which any participant has the right to add an entry or serve as host and validator</li>
+                  <li><b>Light clients</b> via merkelized proofs and proof-of-work allow for lightweight name resolutions and certificates. The initial protocol enables cryptographic name proofs, with the potential for decentralized proof lookups to be usually within the MTU limit.</li>
+                  <li><b>A platform for sybil resilience</b>.  WoT can/should be used as an augmentation, but it is often not a global agreement of resources for individual decentralized services. By using Handshake names, one can know that some kind of economic limits exist for the use of the name. This can be leveraged whenever one is concerned about resource exhaustion, and reaching global agreement on moderation alone is too costly.</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="default" id="coins">
+          <div class="section-content default-bg">
+            <div class="section-wrapper">
+              <div class="columns">
+                <div>
+                  <h2>INTERNET NAME TRANSFERS USING COINS TO PREVENT SYBIL ATTACKS</h2>
+                  <p>Handshake is a piece of software (and a loose consensus on agreement of the software itself). This software's primary function is for people to come to agreement on names and cryptographic keys authorized to represent that names in a decentralized way. To do this in a decentralized way, we need to prevent a single party from claiming all the names. Therefore, a unit of account is needed to prevent that single party from claiming all names.</p>
+                  <p>Handshake uses a coin system for name registration. The Handshake coin (HNS) is the mechanism by which participants transfer, register, and update internet names. The community will be able to initiate auctions and place bids for top-level domains using HNS or trade their HNS as they see fit, with differing value per name.</p>
+                  <p>Therefore, Handshake allocates the majority of its initial coins towards the FOSS community with absolutely no obligation attached, as it is this community most relevant with decentralized software and tools. The goal of the initial design was to account for all possible stakeholders. <a href="/grant-sponsors">More info</a>.</p>
+                  <p>Handshake's incentive design assumptions relies upon Metcalfe's Law (Beckstrom's Law, etc.). While Bitcoin's value is derived from it being a costly store of value, Handshake's value is derived from its network of users. Metcalfe's Law asserts that an increase in userbase increases the value of the network (sub)exponentially. This means that allocation of value to potential developers and users of this system be a benefit to everyone, with network effect derived benefiting all users.</p>
+                </div>
+                <div>
+                  <div class='faucet-cta'>
+                    <h3>Free and Open Source Developers</h3>
+                    <div class='columns'>
+                      <p>Majority ownership of HNS can be claimed by Free and Open Source Software contributors directly to the network itself on-chain. <a href='/claim'> Read more here.</a></p>
+                    </div>
+                    <div class='columns'>
+                      <p>Top github users and PGP WoT Strong Set are the primary set (along with several other communities). This list is <b>not</b> a "toplist of FOSS developers and advocates" and inclusion does not imply that one is a top contributor, this was a list optimized towards availability of scrapeable unique public keys, as the keys are claimed in a decentralized way after the list was generated, and cannot be modified after Handshake goes live without a subsequent hard-fork allocation.</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+      </div> 
+    </div> 
+
+    <footer id='footer'>
+      <div class='footer-wrap'>
+        <nav>
+          <div class='header'>
+            <h3>Handshake</h3>
+            <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+            <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+          </div>
+          <div class='links'>
+            <a href='/'>Home</a>
+            <a href='/community'>Community</a>
+          </div>
+        </nav>
+
+        <nav>
+          <div class='header'>
+            <h3>Learn</h3>
+            <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+            <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+          </div>
+          <div class='links'>
+            <a href='/faq'>FAQ</a>
+            <a href='/files/handshake.txt'>Design Notes</a>
+          </div>
+        </nav>
+
+        <nav>
+          <div class='header'>
+            <h3>Develop</h3>
+            <span><img class='footer-caret-down' src='/img/footer/down-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+            <span><img class='footer-caret-up hide' src='/img/footer/up-caret.svg' alt='Toggle expanded menu on mobile'/></span>
+          </div>
+          <div class='links'>
+            <a href='https://handshake-org.github.io'>Documentation</a>
+            <a href='https://github.com/handshake-org/hsd'>Run a full node</a>
+            <a href='https://github.com/handshake-org/hnsd'>Install an SPV resolver</a>
+            <a href='https://handshake-org.github.io/guides/auctions.html'>Auction system guide</a>
+          </div>
+        </nav>
+
+        <nav style="display:none;">
+        </nav>
+      </div>
+      <div class='footer-wrap bottom-wrap'>
+        <a href='/'>
+          Home
+        </a>
+        <a href='/terms-of-use'>
+          Terms of Use
+        </a>
+        <a href='/privacy-policy'>
+            Privacy Policy
+        </a>
+        <a href='/trademark-disclaimer'>
+            Trademark Disclaimer
+        </a>
+
+        <nav class='social-icons-small-footer'>
+          <a href='https://github.com/handshake-org/'>
+            <img src='/img/footer/github.svg' alt='GitHub logo'/>
+          </a>
+          <a href='https://twitter.com/hns'>
+            <img src='/img/footer/twitter.svg' alt='Twitter logo'/>
+          </a>
+          <a href='https://reddit.com/r/handshake'>
+            <img src='/img/footer/reddit.svg' alt='Reddit logo'/>
+          </a>
+        </nav>
+      </div>
+    </footer>
+
+    <script src='/js/footer.js'></script>
+    <script src='/js/nav.js'></script>
+    <script>
+      window.addEventListener("load", function(e) {
+        document.documentElement.className = '';
+      });
+    </script>
+
+    <script>
+      // Manual toggle for the mobile menu
+      document.getElementById('nav-toggle').addEventListener('click', function() {
+        document.getElementById('burgernav').classList.toggle('open');
+        document.getElementById('overlay').classList.toggle('open');
+      });
+
+      // Close the menu if you click the overlay
+      document.getElementById('overlay').addEventListener('click', function() {
+        document.getElementById('burgernav').classList.remove('open');
+        document.getElementById('overlay').classList.remove('open');
+      });
+    </script>
+
+    <script>
+      // 1. REVEAL EFFECT (Keep this!)
+      const observerOptions = { threshold: 0.1 };
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('active');
+          }
+        });
+      }, observerOptions);
+
+      document.querySelectorAll('.reveal, section').forEach(el => {
+        observer.observe(el);
+      });
+
+      // --- THEME TOGGLE LOGIC ---
+      const themeToggle = document.getElementById('theme-toggle');
+      const htmlElement = document.documentElement;
+
+      function applyTheme(theme) {
+        const isDark = theme === 'dark';
+        htmlElement.setAttribute('data-theme', theme);
+        localStorage.setItem('theme', theme);
+        
+        if (themeToggle) {
+          themeToggle.innerText = isDark ? 'LIGHT MODE' : 'DARK MODE';
+          // Use the variables directly or hardcode them to match the theme
+          themeToggle.style.borderColor = isDark ? '#00ff41' : '#0033ff';
+          themeToggle.style.color = isDark ? '#00ff41' : '#0033ff';
+        }
+      }
+
+      const savedTheme = localStorage.getItem('theme') || 'dark';
+      applyTheme(savedTheme);
+
+      if (themeToggle) {
+        themeToggle.addEventListener('click', () => {
+          const newTheme = htmlElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+          applyTheme(newTheme);
+        });
+      }
+
+      // Trigger once on load to set initial positions
+      window.dispatchEvent(new Event('scroll'));
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
This pull request is to refresh and modernize the styling of handshake.org, adding a hero header, dark mode/light mode, polygonal section transitions, and general clean up/restructuring.  It also adds a "Wiki" link to Handypedia.org, to establish that site as the default wiki for the project.

Some minor portions of the content have been adjusted to remove the "experimental" verbiage and more should be cleaned up - i.e. closure of the developer airdrop, etc.

Preview can be viewed via Cloudflare tunnel here: 
https://handshake-web-refresh.yocom.net

This is my first pull request, ever...  so please feel free to ask questions, etc.  I'm sure I may have missed something.
